### PR TITLE
Add support for RoseStacker

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -81,6 +81,7 @@ dependencies {
     compileOnly "com.stefthedev:Villages:latest"
     compileOnly "com.bgsoftware:WildChestsAPI:latest"
     compileOnly "com.bgsoftware:WildStackerAPI:latest"
+    compileOnly "dev.rosewood:RoseStacker:latest"
 }
 
 jar {

--- a/src/main/java/com/bgsoftware/wildtools/handlers/ProvidersHandler.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/ProvidersHandler.java
@@ -18,6 +18,7 @@ import com.bgsoftware.wildtools.hooks.ContainerProvider_WildChests;
 import com.bgsoftware.wildtools.api.hooks.DropsProvider;
 import com.bgsoftware.wildtools.hooks.DropsProvider_ChunkHoppers;
 import com.bgsoftware.wildtools.hooks.DropsProvider_MergedSpawner;
+import com.bgsoftware.wildtools.hooks.DropsProvider_RoseStacker;
 import com.bgsoftware.wildtools.hooks.DropsProvider_SilkSpawners;
 import com.bgsoftware.wildtools.hooks.DropsProvider_WildStacker;
 import com.bgsoftware.wildtools.hooks.DropsProvider_mcMMO;
@@ -238,6 +239,9 @@ public final class ProvidersHandler implements ProvidersManager {
         }
         else if(Bukkit.getPluginManager().isPluginEnabled("MergedSpawner")) {
             addDropsProvider(new DropsProvider_MergedSpawner());
+        }
+        else if(Bukkit.getPluginManager().isPluginEnabled("RoseStacker")) {
+            addDropsProvider(new DropsProvider_RoseStacker());
         }
         else {
             addDropsProvider(new DropsProviders_WildToolsSpawners());

--- a/src/main/java/com/bgsoftware/wildtools/hooks/DropsProvider_RoseStacker.java
+++ b/src/main/java/com/bgsoftware/wildtools/hooks/DropsProvider_RoseStacker.java
@@ -1,0 +1,40 @@
+package com.bgsoftware.wildtools.hooks;
+
+import com.bgsoftware.wildtools.api.hooks.DropsProvider;
+import dev.rosewood.rosestacker.api.RoseStackerAPI;
+import dev.rosewood.rosestacker.stack.StackedSpawner;
+import dev.rosewood.rosestacker.utils.ItemUtils;
+import java.util.ArrayList;
+import java.util.List;
+import org.bukkit.block.Block;
+import org.bukkit.block.CreatureSpawner;
+import org.bukkit.entity.Player;
+import org.bukkit.inventory.ItemStack;
+
+public final class DropsProvider_RoseStacker implements DropsProvider {
+
+    @Override
+    public List<ItemStack> getBlockDrops(Player player, Block block) {
+        List<ItemStack> drops = new ArrayList<>();
+
+        if (!(block.getState() instanceof CreatureSpawner))
+            return drops;
+
+        StackedSpawner stackedSpawner = RoseStackerAPI.getInstance().getStackedSpawner(block);
+        if (stackedSpawner != null) {
+            drops.add(ItemUtils.getSpawnerAsStackedItemStack(stackedSpawner.getSpawner().getSpawnedType(), stackedSpawner.getStackSize()));
+            stackedSpawner.setStackSize(0);
+            stackedSpawner.updateDisplay();
+            RoseStackerAPI.getInstance().removeSpawnerStack(stackedSpawner);
+        } else {
+            drops.add(DropsProviders_WildToolsSpawners.getSpawnerItem((CreatureSpawner) block.getState()));
+        }
+
+        return drops;
+    }
+
+    @Override
+    public boolean isSpawnersOnly() {
+        return true;
+    }
+}

--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -5,7 +5,7 @@ main: com.bgsoftware.wildtools.WildToolsPlugin
 description: Configurable trench picks, tray picks, sell-wands, harvester-hoes and more!
 website: https://bg-software.com/
 authors: [Ome_R]
-softdepend: [AcidIsland, ASkyBlock, ChunkCollectors, BentoBox, CMI, Essentials, FabledSkyBlock, Factions, FactionsX, GriefPrevention, IslandWorld, Jobs, Lands, LockettePro, MassiveCore, mcMMO, PlotSquared, QuickShop, Residence, ShopGUIPlus, SilkSpawners, SuperiorSkyblock2, SuperMobCoins, Towny, Villages, VoidChest, WildChests, WildStacker, WorldGuard]
+softdepend: [AcidIsland, ASkyBlock, ChunkCollectors, BentoBox, CMI, Essentials, FabledSkyBlock, Factions, FactionsX, GriefPrevention, IslandWorld, Jobs, Lands, LockettePro, MassiveCore, mcMMO, PlotSquared, QuickShop, Residence, RoseStacker, ShopGUIPlus, SilkSpawners, SuperiorSkyblock2, SuperMobCoins, Towny, Villages, VoidChest, WildChests, WildStacker, WorldGuard]
 commands:
   tools:
     description: List of all wildtools command


### PR DESCRIPTION
Adds support for [RoseStacker](https://www.spigotmc.org/resources/rosestacker.82729/) spawners to the crowbar tool.