### PR TITLE
Tools registry

### DIFF
--- a/API/src/main/java/com/bgsoftware/wildtools/api/events/PluginInitializeEvent.java
+++ b/API/src/main/java/com/bgsoftware/wildtools/api/events/PluginInitializeEvent.java
@@ -1,0 +1,22 @@
+package com.bgsoftware.wildtools.api.events;
+
+import com.bgsoftware.wildtools.api.WildTools;
+import org.bukkit.event.Event;
+import org.bukkit.event.HandlerList;
+
+public final class PluginInitializeEvent extends Event {
+    private static final HandlerList HANDLERS = new HandlerList();
+    private final WildTools plugin;
+
+    public PluginInitializeEvent(WildTools plugin) {
+        this.plugin = plugin;
+    }
+
+    public WildTools getPlugin() {
+        return plugin;
+    }
+
+    @Override public HandlerList getHandlers() { return HANDLERS; }
+    public static HandlerList getHandlerList() { return HANDLERS; }
+}
+

--- a/API/src/main/java/com/bgsoftware/wildtools/api/handlers/ToolsManager.java
+++ b/API/src/main/java/com/bgsoftware/wildtools/api/handlers/ToolsManager.java
@@ -1,6 +1,6 @@
 package com.bgsoftware.wildtools.api.handlers;
 
-import com.bgsoftware.wildtools.api.objects.Selection;
+import com.bgsoftware.wildtools.api.objects.*;
 import com.bgsoftware.wildtools.api.objects.tools.BuilderTool;
 import com.bgsoftware.wildtools.api.objects.tools.CannonTool;
 import com.bgsoftware.wildtools.api.objects.tools.CraftingTool;
@@ -19,6 +19,7 @@ import com.bgsoftware.wildtools.api.objects.tools.IceTool;
 import com.bgsoftware.wildtools.api.objects.tools.SellTool;
 
 import java.util.List;
+import java.util.Map;
 
 public interface ToolsManager {
 
@@ -133,14 +134,46 @@ public interface ToolsManager {
     double getPrice(Player player, ItemStack itemStack);
 
     /**
+     * Register a new tool kind.
+     * @param kind The tool kind to register.
+     * @param factory The factory for creating tools of this kind.
+     */
+    void registerToolKind(ToolKind kind,
+                          ToolKindFactory factory);
+
+    /**
+     * Get a tool kind by its id.
+     * @param id The id to check.
+     * @return If exists, the tool kind. Otherwise, null.
+     */
+    ToolKind getKind(String id);
+
+    /**
+     * Get all the registered tool kinds.
+     */
+    Map<String, ToolKind> getRegisteredKinds();
+
+    /**
      * Register a new tool.
      * @param type The type of the tool.
      * @param name The name of the tool.
      * @param toolClass The tool class.
      * @param arg Additional arguments for the item.
      * @return The new tool.
+     * @deprecated Use {@link #registerTool(String, Material, String, ToolSectionView)} instead.
      */
+    @Deprecated
     <T extends Tool> T registerTool(Material type, String name, Class<T> toolClass, Object arg);
+
+    /**
+     * Register a new tool.
+     * @param kindId The kind id of the tool.
+     * @param type The type of the tool.
+     * @param name The name of the tool.
+     * @param cfg The tool section view configuration.
+     * @return The new tool.
+     */
+    <T extends Tool> T registerTool(String kindId, Material type, String name, ToolSectionView cfg);
 
     /**
      * Check whether or not a player is owning an item or not.

--- a/API/src/main/java/com/bgsoftware/wildtools/api/objects/ToolKind.java
+++ b/API/src/main/java/com/bgsoftware/wildtools/api/objects/ToolKind.java
@@ -6,7 +6,11 @@ import com.bgsoftware.wildtools.api.objects.tools.Tool;
 public interface ToolKind {
     String id();
 
-    int sortOrder();
+    default int sortOrder() {
+        return 0;
+    }
 
-    boolean isSimilar(ItemStack stack, Tool tool);
+    default boolean isSimilar(ItemStack stack, Tool tool) {
+        return tool.isSimilar(stack);
+    }
 }

--- a/API/src/main/java/com/bgsoftware/wildtools/api/objects/ToolKind.java
+++ b/API/src/main/java/com/bgsoftware/wildtools/api/objects/ToolKind.java
@@ -1,0 +1,12 @@
+package com.bgsoftware.wildtools.api.objects;
+
+import org.bukkit.inventory.ItemStack;
+import com.bgsoftware.wildtools.api.objects.tools.Tool;
+
+public interface ToolKind {
+    String id();
+
+    int sortOrder();
+
+    boolean isSimilar(ItemStack stack, Tool tool);
+}

--- a/API/src/main/java/com/bgsoftware/wildtools/api/objects/ToolKindFactory.java
+++ b/API/src/main/java/com/bgsoftware/wildtools/api/objects/ToolKindFactory.java
@@ -1,0 +1,9 @@
+package com.bgsoftware.wildtools.api.objects;
+
+import org.bukkit.Material;
+import com.bgsoftware.wildtools.api.objects.tools.Tool;
+
+@FunctionalInterface
+public interface ToolKindFactory {
+    Tool create(Material type, String name, ToolSectionView cfg);
+}

--- a/API/src/main/java/com/bgsoftware/wildtools/api/objects/ToolSectionView.java
+++ b/API/src/main/java/com/bgsoftware/wildtools/api/objects/ToolSectionView.java
@@ -1,0 +1,19 @@
+package com.bgsoftware.wildtools.api.objects;
+
+import java.util.List;
+
+public interface ToolSectionView {
+    boolean contains(String path);
+
+    String getString(String path, String def);
+
+    int getInt(String path, int def);
+
+    long getLong(String path, long def);
+
+    double getDouble(String path, double def);
+
+    boolean getBoolean(String path, boolean def);
+
+    List<String> getStringList(String path);
+}

--- a/API/src/main/java/com/bgsoftware/wildtools/api/objects/tools/BaseTool.java
+++ b/API/src/main/java/com/bgsoftware/wildtools/api/objects/tools/BaseTool.java
@@ -1,0 +1,444 @@
+package com.bgsoftware.wildtools.api.objects.tools;
+
+import com.bgsoftware.wildtools.api.objects.ToolKind;
+import org.bukkit.Material;
+import org.bukkit.event.block.BlockBreakEvent;
+import org.bukkit.event.player.PlayerInteractEvent;
+import org.bukkit.inventory.ItemStack;
+
+import java.util.List;
+import java.util.Set;
+import java.util.UUID;
+
+public abstract class BaseTool implements Tool {
+
+    private final Material type;
+    private final String name;
+    private final ToolKind kind;
+
+    private Tool delegate;
+
+    protected BaseTool(Material type, String name, ToolKind kind) {
+        this.type = type;
+        this.name = name;
+        this.kind = kind;
+    }
+
+    public final void bindDelegate(Tool delegate) {
+        this.delegate = delegate;
+    }
+
+    @Override
+    public String getName() {
+        return name;
+    }
+
+    @Override
+    public ToolKind getKind() {
+        return kind;
+    }
+
+    @Override
+    public void setDisplayName(String n) {
+        delegate.setDisplayName(n);
+    }
+
+    @Override
+    public void setLore(List<String> lore) {
+        delegate.setLore(lore);
+    }
+
+    @Override
+    public void setSpigotUnbreakable(boolean b) {
+        delegate.setSpigotUnbreakable(b);
+    }
+
+    @Override
+    public void setCustomModel(int i) {
+        delegate.setCustomModel(i);
+    }
+
+    @Override
+    public void setOnlySameType(boolean b) {
+        delegate.setOnlySameType(b);
+    }
+
+    @Override
+    public void setOnlyInsideClaim(boolean b) {
+        delegate.setOnlyInsideClaim(b);
+    }
+
+    @Override
+    public void setAutoCollect(boolean b) {
+        delegate.setAutoCollect(b);
+    }
+
+    @Override
+    public void setInstantBreak(boolean b) {
+        delegate.setInstantBreak(b);
+    }
+
+    @Override
+    public void setSilkTouch(boolean b) {
+        delegate.setSilkTouch(b);
+    }
+
+    @Override
+    public void setUnbreakable(boolean b) {
+        delegate.setUnbreakable(b);
+    }
+
+    @Override
+    public void setVanillaDamage(boolean b) {
+        delegate.setVanillaDamage(b);
+    }
+
+    @Override
+    public void setUsesLeft(int i) {
+        delegate.setUsesLeft(i);
+    }
+
+    @Override
+    public void setCooldown(long l) {
+        delegate.setCooldown(l);
+    }
+
+    @Override
+    public void setKeepInventory(boolean b) {
+        delegate.setKeepInventory(b);
+    }
+
+    @Override
+    public void setOmni(boolean b) {
+        delegate.setOmni(b);
+    }
+
+    @Override
+    public void setPrivate(boolean b) {
+        delegate.setPrivate(b);
+    }
+
+    @Override
+    public void setUsesProgress(boolean b) {
+        delegate.setUsesProgress(b);
+    }
+
+    @Override
+    public void addEnchantment(org.bukkit.enchantments.Enchantment e, int lvl) {
+        delegate.addEnchantment(e, lvl);
+    }
+
+    @Override
+    public void addBlacklistedMaterial(String t) {
+        delegate.addBlacklistedMaterial(t);
+    }
+
+    @Override
+    public void addWhitelistedMaterial(String t) {
+        delegate.addWhitelistedMaterial(t);
+    }
+
+    @Override
+    public void addBlacklistedDrop(String t) {
+        delegate.addBlacklistedDrop(t);
+    }
+
+    @Override
+    public void addWhitelistedDrop(String t) {
+        delegate.addWhitelistedDrop(t);
+    }
+
+    @Override
+    public void setMultiplier(double m) {
+        delegate.setMultiplier(m);
+    }
+
+    @Override
+    public void setAnvilCombineExp(int i) {
+        delegate.setAnvilCombineExp(i);
+    }
+
+    @Override
+    public void setAnvilCombineLimit(int i) {
+        delegate.setAnvilCombineLimit(i);
+    }
+
+    @Override
+    public void setBlacklistedWorlds(List<String> w) {
+        delegate.setBlacklistedWorlds(w);
+    }
+
+    @Override
+    public void setWhitelistedWorlds(List<String> w) {
+        delegate.setWhitelistedWorlds(w);
+    }
+
+    @Override
+    public void setStatistics(boolean b) {
+        delegate.setStatistics(b);
+    }
+
+    @Override
+    public void setNotifiedPlugins(List<String> p) {
+        delegate.setNotifiedPlugins(p);
+    }
+
+    @Override
+    public org.bukkit.inventory.ItemStack getItemStack() {
+        return delegate.getItemStack();
+    }
+
+    @Override
+    public ItemStack getFormattedItemStack() {
+        return delegate.getFormattedItemStack();
+    }
+
+    @Override
+    public ItemStack getFormattedItemStack(int uses) {
+        return delegate.getFormattedItemStack(uses);
+    }
+
+    @Override
+    public com.bgsoftware.wildtools.api.objects.ToolMode getToolMode() {
+        return delegate.getToolMode();
+    }
+
+    @Override
+    public boolean isUnbreakable() {
+        return delegate.isUnbreakable();
+    }
+
+    @Override
+    public boolean hasVanillaDamage() {
+        return delegate.hasVanillaDamage();
+    }
+
+    @Override
+    public boolean isAutoCollect() {
+        return delegate.isAutoCollect();
+    }
+
+    @Override
+    public boolean isInstantBreak() {
+        return delegate.isInstantBreak();
+    }
+
+    @Override
+    public boolean hasSilkTouch() {
+        return delegate.hasSilkTouch();
+    }
+
+    @Override
+    public int getDefaultUses() {
+        return delegate.getDefaultUses();
+    }
+
+    @Override
+    public boolean isUsingDurability() {
+        return delegate.isUsingDurability();
+    }
+
+    @Override
+    public boolean isOnlySameType() {
+        return delegate.isOnlySameType();
+    }
+
+    @Override
+    public boolean isOnlyInsideClaim() {
+        return delegate.isOnlyInsideClaim();
+    }
+
+    @Override
+    public long getCooldown() {
+        return delegate.getCooldown();
+    }
+
+    @Override
+    public boolean hasKeepInventory() {
+        return delegate.hasKeepInventory();
+    }
+
+    @Override
+    public boolean isOmni() {
+        return delegate.isOmni();
+    }
+
+    @Override
+    public boolean isPrivate() {
+        return delegate.isPrivate();
+    }
+
+    @Override
+    public boolean isUsesProgress() {
+        return delegate.isUsesProgress();
+    }
+
+    @Override
+    public boolean isAnvilCombine() {
+        return delegate.isAnvilCombine();
+    }
+
+    @Override
+    public boolean hasAnvilCombineLimit() {
+        return delegate.hasAnvilCombineLimit();
+    }
+
+    @Override
+    public Set<String> getBlacklistedMaterials() {
+        return delegate.getBlacklistedMaterials();
+    }
+
+    @Override
+    public Set<String> getWhitelistedMaterials() {
+        return delegate.getWhitelistedMaterials();
+    }
+
+    @Override
+    public Set<String> getBlacklistedDrops() {
+        return delegate.getBlacklistedDrops();
+    }
+
+    @Override
+    public Set<String> getWhitelistedDrops() {
+        return delegate.getWhitelistedDrops();
+    }
+
+    @Override
+    public Set<String> getNotifiedPlugins() {
+        return delegate.getNotifiedPlugins();
+    }
+
+    @Override
+    public boolean hasBlacklistedMaterials() {
+        return delegate.hasBlacklistedMaterials();
+    }
+
+    @Override
+    public boolean hasWhitelistedMaterials() {
+        return delegate.hasWhitelistedMaterials();
+    }
+
+    @Override
+    public boolean hasBlacklistedDrops() {
+        return delegate.hasBlacklistedDrops();
+    }
+
+    @Override
+    public boolean hasWhitelistedDrops() {
+        return delegate.hasWhitelistedDrops();
+    }
+
+    @Override
+    public boolean isBlacklistedMaterial(org.bukkit.Material t, short d) {
+        return delegate.isBlacklistedMaterial(t, d);
+    }
+
+    @Override
+    public boolean isWhitelistedMaterial(org.bukkit.Material t, short d) {
+        return delegate.isWhitelistedMaterial(t, d);
+    }
+
+    @Override
+    public boolean isBlacklistedDrop(org.bukkit.Material t, short d) {
+        return delegate.isBlacklistedDrop(t, d);
+    }
+
+    @Override
+    public boolean isWhitelistedDrop(org.bukkit.Material t, short d) {
+        return delegate.isWhitelistedDrop(t, d);
+    }
+
+    @Override
+    public double getMultiplier() {
+        return delegate.getMultiplier();
+    }
+
+    @Override
+    public int getAnvilCombineExp() {
+        return delegate.getAnvilCombineExp();
+    }
+
+    @Override
+    public int getAnvilCombineLimit() {
+        return delegate.getAnvilCombineLimit();
+    }
+
+    @Override
+    public boolean isBlacklistedWorld(String w) {
+        return delegate.isBlacklistedWorld(w);
+    }
+
+    @Override
+    public boolean isWhitelistedWorld(String w) {
+        return delegate.isWhitelistedWorld(w);
+    }
+
+    @Override
+    public boolean hasStatistics() {
+        return delegate.hasStatistics();
+    }
+
+    @Override
+    public void reduceDurablility(org.bukkit.entity.Player p, int amt, ItemStack tool) {
+        delegate.reduceDurablility(p, amt, tool);
+    }
+
+    @Override
+    public int getDurability(org.bukkit.entity.Player p, ItemStack is) {
+        return delegate.getDurability(p, is);
+    }
+
+    @Override
+    public boolean canBreakBlock(org.bukkit.block.Block b, Material ft, short fd) {
+        return delegate.canBreakBlock(b, ft, fd);
+    }
+
+    @Override
+    public List<ItemStack> filterDrops(List<ItemStack> drops) {
+        return delegate.filterDrops(drops);
+    }
+
+    @Override
+    public boolean isSimilar(ItemStack is) {
+        return delegate.isSimilar(is);
+    }
+
+    @Override
+    public void setLastUse(UUID u) {
+        delegate.setLastUse(u);
+    }
+
+    @Override
+    public boolean canUse(UUID u) {
+        return delegate.canUse(u);
+    }
+
+    @Override
+    public long getTimeLeft(UUID u) {
+        return delegate.getTimeLeft(u);
+    }
+
+    @Override
+    public boolean onBlockBreak(BlockBreakEvent e) {
+        return delegate.onBlockBreak(e);
+    }
+
+    @Override
+    public boolean onBlockInteract(PlayerInteractEvent e) {
+        return delegate.onBlockInteract(e);
+    }
+
+    @Override
+    public boolean onBlockHit(PlayerInteractEvent e) {
+        return delegate.onBlockHit(e);
+    }
+
+    @Override
+    public boolean onAirInteract(PlayerInteractEvent e) {
+        return delegate.onAirInteract(e);
+    }
+
+    public Material getType() {
+        return type;
+    }
+}

--- a/API/src/main/java/com/bgsoftware/wildtools/api/objects/tools/Tool.java
+++ b/API/src/main/java/com/bgsoftware/wildtools/api/objects/tools/Tool.java
@@ -1,5 +1,6 @@
 package com.bgsoftware.wildtools.api.objects.tools;
 
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import org.bukkit.Material;
 import org.bukkit.block.Block;
@@ -229,6 +230,11 @@ public interface Tool {
      * Get the tool mode.
      */
     ToolMode getToolMode();
+
+    /**
+     * Get the kind of the tool.
+     */
+    ToolKind getKind();
 
     /**
      * Get the name of the tool.

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'WildTools'
-version = "2025.1"
+version = "2025.6"
 
 project.ext {
     archiveFolder = file("archive/")

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ plugins {
 }
 
 group 'WildTools'
-version = "2025.6"
+version = "2025.1"
 
 project.ext {
     archiveFolder = file("archive/")

--- a/src/main/java/com/bgsoftware/wildtools/WildToolsPlugin.java
+++ b/src/main/java/com/bgsoftware/wildtools/WildToolsPlugin.java
@@ -8,6 +8,7 @@ import com.bgsoftware.common.nmsloader.config.NMSConfiguration;
 import com.bgsoftware.common.updater.Updater;
 import com.bgsoftware.wildtools.api.WildTools;
 import com.bgsoftware.wildtools.api.WildToolsAPI;
+import com.bgsoftware.wildtools.api.events.PluginInitializeEvent;
 import com.bgsoftware.wildtools.command.CommandsHandler;
 import com.bgsoftware.wildtools.events.EventsSimulation;
 import com.bgsoftware.wildtools.handlers.DataHandler;
@@ -25,6 +26,7 @@ import com.bgsoftware.wildtools.nms.NMSWorld;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
+import org.bukkit.plugin.RegisteredServiceProvider;
 import org.bukkit.plugin.java.JavaPlugin;
 
 import java.lang.reflect.Field;
@@ -84,8 +86,15 @@ public class WildToolsPlugin extends JavaPlugin implements WildTools {
         getCommand("tools").setTabCompleter(commandsHandler);
 
         providersHandler = new ProvidersHandler(this);
-        toolsManager = new ToolsHandler(this);
         eventsHandler = new EventsHandler();
+
+        toolsManager = new ToolsHandler(this);
+
+        this.toolsManager.registerBuiltinKindsPublic();
+
+        getServer().getPluginManager().callEvent(
+                new PluginInitializeEvent(this)
+        );
 
         DataHandler.loadData();
         Locale.reload();

--- a/src/main/java/com/bgsoftware/wildtools/handlers/DataHandler.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/DataHandler.java
@@ -3,31 +3,15 @@ package com.bgsoftware.wildtools.handlers;
 import com.bgsoftware.common.config.CommentedConfiguration;
 import com.bgsoftware.wildtools.SellWandLogger;
 import com.bgsoftware.wildtools.WildToolsPlugin;
-import com.bgsoftware.wildtools.api.objects.tools.BuilderTool;
-import com.bgsoftware.wildtools.api.objects.tools.CannonTool;
-import com.bgsoftware.wildtools.api.objects.tools.CraftingTool;
-import com.bgsoftware.wildtools.api.objects.tools.CrowbarTool;
-import com.bgsoftware.wildtools.api.objects.tools.CuboidTool;
-import com.bgsoftware.wildtools.api.objects.tools.DrainTool;
-import com.bgsoftware.wildtools.api.objects.tools.HarvesterTool;
-import com.bgsoftware.wildtools.api.objects.tools.IceTool;
-import com.bgsoftware.wildtools.api.objects.tools.LightningTool;
-import com.bgsoftware.wildtools.api.objects.tools.MagnetTool;
-import com.bgsoftware.wildtools.api.objects.tools.PillarTool;
-import com.bgsoftware.wildtools.api.objects.tools.SellTool;
-import com.bgsoftware.wildtools.api.objects.tools.SortTool;
-import com.bgsoftware.wildtools.api.objects.tools.Tool;
-import com.bgsoftware.wildtools.hooks.PricesProvider_Default;
+import com.bgsoftware.wildtools.handlers.config.YamlToolSectionView;
 import com.bgsoftware.wildtools.scheduler.Scheduler;
-import com.bgsoftware.wildtools.tools.WTool;
+import com.bgsoftware.wildtools.hooks.PricesProvider_Default;
+
 import org.bukkit.Material;
-import org.bukkit.enchantments.Enchantment;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class DataHandler {
 
@@ -52,9 +36,7 @@ public class DataHandler {
         }
 
         CommentedConfiguration cfg = CommentedConfiguration.loadConfiguration(file);
-
-        if (cfg.hasFailed())
-            return;
+        if (cfg.hasFailed()) return;
 
         try {
             cfg.syncWithConfig(file, plugin.getResource("config.yml"), "tools");
@@ -83,216 +65,30 @@ public class DataHandler {
                     } else if (split.length == 3) {
                         prices.put(split[0] + ":" + split[1], Double.valueOf(split[2]));
                     }
-                } catch (IllegalArgumentException ignored) {
-                }
+                } catch (IllegalArgumentException ignored) {}
             }
         }
 
         PricesProvider_Default.prices = prices;
 
         for (String name : cfg.getConfigurationSection("tools").getKeys(false)) {
+            String base = "tools." + name;
+            String kindId = cfg.getString(base + ".tool-mode", "").toUpperCase();
             Material type;
 
             try {
-                type = Material.valueOf(cfg.getString("tools." + name + ".type"));
+                type = Material.valueOf(cfg.getString(base + ".type"));
             } catch (IllegalArgumentException e) {
                 WildToolsPlugin.log("Couldn't find a valid type for tool " + name + ", skipping");
                 continue;
             }
 
-            Tool tool;
-
-            switch (cfg.getString("tools." + name + ".tool-mode", "")) {
-                case "BUILDER":
-                    if (!cfg.contains("tools." + name + ".length")) {
-                        WildToolsPlugin.log("Couldn't find a length for tool " + name + ", skipping");
-                        continue;
-                    }
-
-                    tool = plugin.getToolsManager().registerTool(type, name, BuilderTool.class, cfg.getInt("tools." + name + ".length"));
-                    break;
-                case "CANNON":
-                    if (!cfg.contains("tools." + name + ".tnt-amount")) {
-                        WildToolsPlugin.log("Couldn't find a tnt amount for tool " + name + ", skipping");
-                        continue;
-                    }
-
-                    tool = plugin.getToolsManager().registerTool(type, name, CannonTool.class, cfg.getInt("tools." + name + ".tnt-amount"));
-                    break;
-                case "CRAFTING":
-                    if (!cfg.contains("tools." + name + ".craftings")) {
-                        WildToolsPlugin.log("Couldn't find a craftings list for tool " + name + ", skipping");
-                        continue;
-                    }
-
-                    tool = plugin.getToolsManager().registerTool(type, name, CraftingTool.class, cfg.getStringList("tools." + name + ".craftings"));
-                    break;
-                case "CROWBAR":
-                    tool = plugin.getToolsManager().registerTool(type, name, CrowbarTool.class, cfg.getStringList("tools." + name + ".commands-on-use"));
-                    break;
-                case "CUBOID":
-                    if (!cfg.contains("tools." + name + ".break-level")) {
-                        WildToolsPlugin.log("Couldn't find a break-level for tool " + name + ", skipping");
-                        continue;
-                    }
-
-                    tool = plugin.getToolsManager().registerTool(type, name, CuboidTool.class, cfg.getInt("tools." + name + ".break-level"));
-                    break;
-                case "DRAIN":
-                    if (!cfg.contains("tools." + name + ".radius")) {
-                        WildToolsPlugin.log("Couldn't find a radius for tool " + name + ", skipping");
-                        continue;
-                    }
-
-                    tool = plugin.getToolsManager().registerTool(type, name, DrainTool.class, cfg.getInt("tools." + name + ".radius"));
-                    break;
-                case "HARVESTER":
-                    if (!cfg.contains("tools." + name + ".radius")) {
-                        WildToolsPlugin.log("Couldn't find a radius for tool " + name + ", skipping");
-                        continue;
-                    }
-
-                    tool = plugin.getToolsManager().registerTool(type, name, HarvesterTool.class, cfg.getInt("tools." + name + ".radius"));
-
-                    ((HarvesterTool) tool).setActivationAction(cfg.getString("tools." + name + ".active-action", "RIGHT_CLICK"));
-                    ((HarvesterTool) tool).setFarmlandRadius(cfg.getInt("tools." + name + ".farmland-radius", 0));
-                    ((HarvesterTool) tool).setOneLayerOnly(cfg.getBoolean("tools." + name + ".one-layer-only", false));
-                    break;
-                case "ICE":
-                    if (!cfg.contains("tools." + name + ".radius")) {
-                        WildToolsPlugin.log("Couldn't find a radius for tool " + name + ", skipping");
-                        continue;
-                    }
-
-                    tool = plugin.getToolsManager().registerTool(type, name, IceTool.class, cfg.getInt("tools." + name + ".radius"));
-                    break;
-                case "LIGHTNING":
-                    tool = plugin.getToolsManager().registerTool(type, name, LightningTool.class, null);
-                    break;
-                case "MAGNET":
-                    tool = plugin.getToolsManager().registerTool(type, name, MagnetTool.class, cfg.getInt("tools." + name + ".radius"));
-                    break;
-                case "PILLAR":
-                    tool = plugin.getToolsManager().registerTool(type, name, PillarTool.class, null);
-                    break;
-                case "SELL":
-                    tool = plugin.getToolsManager().registerTool(type, name, SellTool.class, null);
-                    break;
-                case "SORT":
-                    tool = plugin.getToolsManager().registerTool(type, name, SortTool.class, null);
-                    break;
-                default:
-                    continue;
+            if (plugin.getToolsManager().getKind(kindId) == null) {
+                WildToolsPlugin.log("Unknown tool-mode " + kindId + " for " + name + ", skipping");
+                continue;
             }
 
-            if (cfg.contains("tools." + name + ".cooldown"))
-                tool.setCooldown(cfg.getLong("tools." + name + ".cooldown"));
-
-            if (cfg.contains("tools." + name + ".auto-collect"))
-                tool.setAutoCollect(cfg.getBoolean("tools." + name + ".auto-collect"));
-
-            if (cfg.contains("tools." + name + ".instant-break"))
-                tool.setInstantBreak(cfg.getBoolean("tools." + name + ".instant-break"));
-
-            if (cfg.contains("tools." + name + ".silk-touch"))
-                tool.setSilkTouch(cfg.getBoolean("tools." + name + ".silk-touch"));
-
-            if (cfg.contains("tools." + name + ".only-same-type"))
-                tool.setOnlySameType(cfg.getBoolean("tools." + name + ".only-same-type"));
-
-            if (cfg.contains("tools." + name + ".only-inside-claim"))
-                tool.setOnlyInsideClaim(cfg.getBoolean("tools." + name + ".only-inside-claim"));
-
-            if (cfg.contains("tools." + name + ".unbreakable"))
-                tool.setUnbreakable(cfg.getBoolean("tools." + name + ".unbreakable"));
-
-            if (cfg.contains("tools." + name + ".vanilla-damage"))
-                tool.setVanillaDamage(cfg.getBoolean("tools." + name + ".vanilla-damage"));
-
-            if (cfg.contains("tools." + name + ".uses"))
-                tool.setUsesLeft(cfg.getInt("tools." + name + ".uses"));
-
-            if (cfg.contains("tools." + name + ".keep-inventory"))
-                tool.setKeepInventory(cfg.getBoolean("tools." + name + ".keep-inventory"));
-
-            if (cfg.contains("tools." + name + ".name"))
-                tool.setDisplayName(cfg.getString("tools." + name + ".name"));
-
-            if (cfg.contains("tools." + name + ".lore"))
-                tool.setLore(cfg.getStringList("tools." + name + ".lore"));
-
-            if (cfg.getBoolean("tools." + name + ".glow", false)) {
-                ((WTool) tool).makeToolGlow();
-            }
-
-            if (cfg.getBoolean("tools." + name + ".spigot-unbreakable", false))
-                tool.setSpigotUnbreakable(cfg.getBoolean("tools." + name + ".spigot-unbreakable"));
-
-            if (cfg.contains("tools." + name + ".custom-model"))
-                tool.setCustomModel(cfg.getInt("tools." + name + ".custom-model"));
-
-            if (cfg.contains("tools." + name + ".enchants")) {
-                List<String> enchants = cfg.getStringList("tools." + name + ".enchants");
-                for (String line : enchants)
-                    try {
-                        tool.addEnchantment(Enchantment.getByName(line.split(":")[0]),
-                                Integer.parseInt(line.split(":")[1]));
-                    } catch (IllegalArgumentException ignored) {
-                    }
-            }
-
-            if (cfg.contains("tools." + name + ".blacklisted-blocks")) {
-                List<String> materials = cfg.getStringList("tools." + name + ".blacklisted-blocks");
-                for (String mat : materials)
-                    tool.addBlacklistedMaterial(mat);
-            }
-
-            if (cfg.contains("tools." + name + ".whitelisted-blocks")) {
-                List<String> materials = cfg.getStringList("tools." + name + ".whitelisted-blocks");
-                for (String mat : materials)
-                    tool.addWhitelistedMaterial(mat);
-            }
-
-            if (cfg.contains("tools." + name + ".blacklisted-drops")) {
-                List<String> drops = cfg.getStringList("tools." + name + ".blacklisted-drops");
-                for (String drop : drops)
-                    tool.addBlacklistedDrop(drop);
-            }
-
-            if (cfg.contains("tools." + name + ".whitelisted-drops")) {
-                List<String> drops = cfg.getStringList("tools." + name + ".whitelisted-drops");
-                for (String drop : drops)
-                    tool.addWhitelistedDrop(drop);
-            }
-
-            if (cfg.contains("tools." + name + ".multiplier"))
-                tool.setMultiplier(cfg.getDouble("tools." + name + ".multiplier"));
-
-            if (cfg.contains("tools." + name + ".omni-tool") && type.name().contains("_"))
-                tool.setOmni(cfg.getBoolean("tools." + name + ".omni-tool"));
-
-            if (cfg.contains("tools." + name + ".private"))
-                tool.setPrivate(cfg.getBoolean("tools." + name + ".private"));
-
-            if (cfg.contains("tools." + name + ".uses-progress"))
-                tool.setUsesProgress(cfg.getBoolean("tools." + name + ".uses-progress"));
-
-            if (cfg.contains("tools." + name + ".anvil-combine-exp"))
-                tool.setAnvilCombineExp(cfg.getInt("tools." + name + ".anvil-combine-exp"));
-
-            if (cfg.contains("tools." + name + ".anvil-combine-limit"))
-                tool.setAnvilCombineLimit(cfg.getInt("tools." + name + ".anvil-combine-limit"));
-
-            if (cfg.contains("tools." + name + ".blacklisted-worlds")) {
-                tool.setBlacklistedWorlds(cfg.getStringList("tools." + name + ".blacklisted-worlds"));
-            }
-
-            if (cfg.contains("tools." + name + ".whitelisted-worlds")) {
-                tool.setWhitelistedWorlds(cfg.getStringList("tools." + name + ".whitelisted-worlds"));
-            }
-
-            if (cfg.contains("tools." + name + ".notified-plugins"))
-                tool.setNotifiedPlugins(cfg.getStringList("tools." + name + ".notified-plugins"));
+            plugin.getToolsManager().registerTool(kindId, type, name, new YamlToolSectionView(cfg, base));
 
             toolsAmount++;
         }

--- a/src/main/java/com/bgsoftware/wildtools/handlers/ToolsHandler.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/ToolsHandler.java
@@ -128,10 +128,9 @@ public class ToolsHandler implements ToolsManager {
         if (tool instanceof BaseTool) {
             WTool backend = new WTool(type, name, getKind(kindId)) {};
             ((BaseTool) tool).bindDelegate(backend);
-            CommonToolLoader.applyCommonProperties(tool, cfg);
-        } else {
-            CommonToolLoader.applyCommonProperties(tool, cfg);
         }
+
+        CommonToolLoader.applyCommonProperties(tool, cfg);
 
         Tool prev = toolsByName.put(tool.getName().toLowerCase(), tool);
         if (prev != null) tools.remove(prev);

--- a/src/main/java/com/bgsoftware/wildtools/handlers/ToolsHandler.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/ToolsHandler.java
@@ -1,231 +1,221 @@
 package com.bgsoftware.wildtools.handlers;
 
-import com.bgsoftware.wildtools.api.objects.tools.CrowbarTool;
-import com.bgsoftware.wildtools.api.objects.tools.MagnetTool;
-import com.bgsoftware.wildtools.tools.WBuilderTool;
-import com.bgsoftware.wildtools.tools.WCannonTool;
-import com.bgsoftware.wildtools.tools.WCraftingTool;
-import com.bgsoftware.wildtools.tools.WCrowbarTool;
-import com.bgsoftware.wildtools.tools.WCuboidTool;
-import com.bgsoftware.wildtools.tools.WHarvesterTool;
-import com.bgsoftware.wildtools.tools.WIceTool;
-import com.bgsoftware.wildtools.tools.WLightningTool;
-import com.bgsoftware.wildtools.tools.WMagnetTool;
-import com.bgsoftware.wildtools.tools.WPillarTool;
-import com.bgsoftware.wildtools.tools.WSellTool;
-import com.bgsoftware.wildtools.tools.WSortTool;
+import com.bgsoftware.wildtools.WildToolsPlugin;
+import com.bgsoftware.wildtools.api.objects.Selection;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
+import com.bgsoftware.wildtools.api.objects.ToolKindFactory;
+import com.bgsoftware.wildtools.api.objects.ToolSectionView;
+import com.bgsoftware.wildtools.api.objects.ToolMode;
+import com.bgsoftware.wildtools.api.objects.tools.*;
+import com.bgsoftware.wildtools.api.handlers.ToolsManager;
+import com.bgsoftware.wildtools.handlers.kinds.BuiltinKind;
+import com.bgsoftware.wildtools.handlers.legacy.LegacyKindMapper;
+import com.bgsoftware.wildtools.handlers.legacy.ToolSectionViewAdapters;
+import com.bgsoftware.wildtools.handlers.loaders.CommonToolLoader;
+import com.bgsoftware.wildtools.tools.*;
 import com.bgsoftware.wildtools.utils.items.ToolItemStack;
 import org.bukkit.Material;
 import org.bukkit.entity.Player;
 import org.bukkit.inventory.ItemStack;
 
-import com.bgsoftware.wildtools.WildToolsPlugin;
-import com.bgsoftware.wildtools.api.handlers.ToolsManager;
-import com.bgsoftware.wildtools.api.objects.Selection;
-import com.bgsoftware.wildtools.api.objects.ToolMode;
-import com.bgsoftware.wildtools.api.objects.tools.BuilderTool;
-import com.bgsoftware.wildtools.api.objects.tools.CannonTool;
-import com.bgsoftware.wildtools.api.objects.tools.CraftingTool;
-import com.bgsoftware.wildtools.api.objects.tools.CuboidTool;
-import com.bgsoftware.wildtools.api.objects.tools.DrainTool;
-import com.bgsoftware.wildtools.api.objects.tools.HarvesterTool;
-import com.bgsoftware.wildtools.api.objects.tools.IceTool;
-import com.bgsoftware.wildtools.api.objects.tools.LightningTool;
-import com.bgsoftware.wildtools.api.objects.tools.PillarTool;
-import com.bgsoftware.wildtools.api.objects.tools.SellTool;
-import com.bgsoftware.wildtools.api.objects.tools.SortTool;
-import com.bgsoftware.wildtools.api.objects.tools.Tool;
-import com.bgsoftware.wildtools.tools.WDrainTool;
-
-import java.util.ArrayList;
-import java.util.Collections;
-import java.util.Comparator;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
+import java.util.function.Function;
 
 @SuppressWarnings("unchecked")
 public class ToolsHandler implements ToolsManager {
-
-    private static final Comparator<Tool> toolComparator = (o1, o2) -> {
-        int compare = Integer.compare(o1.getToolMode().ordinal(), o2.getToolMode().ordinal());
-        return compare == 0 ? o1.getName().compareToIgnoreCase(o2.getName()) : compare;
-    };
 
     private final WildToolsPlugin plugin;
 
     private final Map<String, Tool> toolsByName = new HashMap<>();
     private final List<Tool> tools = new ArrayList<>();
 
+    private final Map<String, ToolKind> kinds = new HashMap<>();
+    private final Map<String, ToolKindFactory> kindFactories = new HashMap<>();
+
     public ToolsHandler(WildToolsPlugin plugin){
         this.plugin = plugin;
     }
 
-    @Override
-    public BuilderTool getBuilderTool(ItemStack itemStack) {
-        return getTool(itemStack, ToolMode.BUILDER, BuilderTool.class);
+    private static int sortOf(Tool t) {
+        ToolKind k = t.getKind();
+        return k != null ? k.sortOrder() : Integer.MAX_VALUE;
     }
 
-    @Override
-    public CannonTool getCannonTool(ItemStack itemStack){
-        return getTool(itemStack, ToolMode.CANNON, CannonTool.class);
-    }
+    private final Comparator<Tool> toolComparator = (a, b) -> {
+        int c = Integer.compare(sortOf(a), sortOf(b));
+        return c == 0 ? a.getName().compareToIgnoreCase(b.getName()) : c;
+    };
+
+    @Override public BuilderTool getBuilderTool(ItemStack itemStack) { return getToolByKind(itemStack, ToolMode.BUILDER, BuilderTool.class); }
+    @Override public CannonTool getCannonTool(ItemStack itemStack){ return getToolByKind(itemStack, ToolMode.CANNON, CannonTool.class); }
+    @Override public CraftingTool getCraftingTool(ItemStack itemStack){ return getToolByKind(itemStack, ToolMode.CRAFTING, CraftingTool.class); }
+    @Override public CuboidTool getCuboidTool(ItemStack itemStack){ return getToolByKind(itemStack, ToolMode.CUBOID, CuboidTool.class); }
+
+    @Override public DrainTool getDrainTool(ItemStack itemStack) { return getToolByKind(itemStack, ToolMode.DRAIN, DrainTool.class); }
+
+    @Override public HarvesterTool getHarvesterTool(ItemStack itemStack){ return getToolByKind(itemStack, ToolMode.HARVESTER, HarvesterTool.class); }
+    @Override public IceTool getIceTool(ItemStack itemStack) { return getToolByKind(itemStack, ToolMode.ICE, IceTool.class); }
+    @Override public LightningTool getLightningTool(ItemStack itemStack){ return getToolByKind(itemStack, ToolMode.LIGHTNING, LightningTool.class); }
+    @Override public PillarTool getPillarTool(ItemStack itemStack){ return getToolByKind(itemStack, ToolMode.PILLAR, PillarTool.class); }
+    @Override public SellTool getSellTool(ItemStack itemStack){ return getToolByKind(itemStack, ToolMode.SELL, SellTool.class); }
+    @Override public SortTool getSortTool(ItemStack itemStack) { return getToolByKind(itemStack, ToolMode.SORT, SortTool.class); }
 
     @Override
-    public CraftingTool getCraftingTool(ItemStack itemStack){
-        return getTool(itemStack, ToolMode.CRAFTING, CraftingTool.class);
-    }
-
-    @Override
-    public CuboidTool getCuboidTool(ItemStack itemStack){
-        return getTool(itemStack, ToolMode.CUBOID, CuboidTool.class);
-    }
-
-    @Override
-    public DrainTool getDrainTool(ItemStack itemStack) {
-        return getTool(itemStack, ToolMode.CUBOID, DrainTool.class);
-    }
-
-    @Override
-    public HarvesterTool getHarvesterTool(ItemStack itemStack){
-        return getTool(itemStack, ToolMode.HARVESTER, HarvesterTool.class);
-    }
-
-    @Override
-    public IceTool getIceTool(ItemStack itemStack) {
-        return getTool(itemStack, ToolMode.ICE, IceTool.class);
-    }
-
-    @Override
-    public LightningTool getLightningTool(ItemStack itemStack){
-        return getTool(itemStack, ToolMode.LIGHTNING, LightningTool.class);
-    }
-
-    @Override
-    public PillarTool getPillarTool(ItemStack itemStack){
-        return getTool(itemStack, ToolMode.PILLAR, PillarTool.class);
-    }
-
-    @Override
-    public SellTool getSellTool(ItemStack itemStack){
-        return getTool(itemStack, ToolMode.SELL, SellTool.class);
-    }
-
-    @Override
-    public SortTool getSortTool(ItemStack itemStack) {
-        return getTool(itemStack, ToolMode.SORT, SortTool.class);
-    }
-
-    @Override
-    public Tool getTool(String name){
-        return toolsByName.get(name.toLowerCase());
-    }
+    public Tool getTool(String name){ return name == null ? null : toolsByName.get(name.toLowerCase()); }
 
     @Override
     public Tool getTool(ItemStack itemStack){
-        if(itemStack == null)
-            return null;
+        if(itemStack == null) return null;
 
-        ToolItemStack toolItemStack = ToolItemStack.of(itemStack);
+        ToolItemStack tis = ToolItemStack.of(itemStack);
+        String toolName = tis.getToolType();
+        Tool byName = getTool(toolName);
+        if(byName != null) return byName;
 
-        String toolName = toolItemStack.getToolType();
-
-        Tool toolByName = getTool(toolName);
-
-        if(toolByName != null)
-            return toolByName;
-
-        for(Tool tool : tools)
-            if (tool.isSimilar(itemStack))
-                return tool;
-
+        for (Tool t : tools) {
+            ToolKind k = t.getKind();
+            boolean similar = (k != null && k.isSimilar(itemStack, t)) || t.isSimilar(itemStack);
+            if (similar) return t;
+        }
         return null;
     }
 
-    @Override
-    public List<Tool> getTools(){
-        return Collections.unmodifiableList(tools);
-    }
+    @Override public List<Tool> getTools(){ return Collections.unmodifiableList(tools); }
+    public void clearTools(){ tools.clear(); toolsByName.clear(); }
 
-    public void clearTools(){
-        tools.clear();
-    }
+    @Override public Selection getSelection(Player player){ return WCannonTool.getSelection(player); }
 
-    @Override
-    public Selection getSelection(Player player){
-        return WCannonTool.getSelection(player);
-    }
-
-    @Override
-    public double getPrice(Player player, ItemStack itemStack){
-        return plugin.getProviders().getPrice(player, itemStack);
-    }
-
-    @Override
-    public <T extends Tool> T registerTool(Material type, String name, Class<T> toolClass, Object arg) {
-        Tool tool;
-        if(toolClass.isAssignableFrom(BuilderTool.class)){
-            tool = new WBuilderTool(type, name, (int) arg);
-        }else if(toolClass.isAssignableFrom(CannonTool.class)){
-            tool = new WCannonTool(type, name, (int) arg);
-        }else if(toolClass.isAssignableFrom(CraftingTool.class)){
-            tool = new WCraftingTool(type, name, (List<String>) arg);
-        }else if(toolClass.isAssignableFrom(CrowbarTool.class)){
-            tool = new WCrowbarTool(type, name, (List<String>) arg);
-        }else if(toolClass.isAssignableFrom(CuboidTool.class)){
-            tool = new WCuboidTool(type, name, (int) arg);
-        }else if(toolClass.isAssignableFrom(DrainTool.class)){
-            tool = new WDrainTool(type, name, (int) arg);
-        }else if(toolClass.isAssignableFrom(HarvesterTool.class)){
-            tool = new WHarvesterTool(type, name, (int) arg);
-        }else if(toolClass.isAssignableFrom(IceTool.class)){
-            tool = new WIceTool(type, name, (int) arg);
-        }else if(toolClass.isAssignableFrom(LightningTool.class)){
-            tool = new WLightningTool(type, name);
-        }else if(toolClass.isAssignableFrom(MagnetTool.class)){
-            tool = new WMagnetTool(type, name, (int) arg);
-        }else if(toolClass.isAssignableFrom(PillarTool.class)){
-            tool = new WPillarTool(type, name);
-        }else if(toolClass.isAssignableFrom(SellTool.class)){
-            tool = new WSellTool(type, name);
-        }else if(toolClass.isAssignableFrom(SortTool.class)) {
-            tool = new WSortTool(type, name);
-        }else throw new IllegalArgumentException("Couldn't find tool class " + toolClass.getName());
-
-        if(toolsByName.containsKey(tool.getName().toLowerCase()))
-            tools.remove(toolsByName.get(tool.getName().toLowerCase()));
-
-        tools.add(tool);
-        toolsByName.put(tool.getName().toLowerCase(), tool);
-
-        tools.sort(toolComparator);
-
-        return toolClass.cast(tool);
-    }
+    @Override public double getPrice(Player player, ItemStack itemStack){ return plugin.getProviders().getPrice(player, itemStack); }
 
     @Override
     public boolean isOwningTool(ItemStack itemStack, Player player) {
-        ToolItemStack toolItemStack = ToolItemStack.of(itemStack);
-        Tool tool = toolItemStack.getTool();
-
-        if(tool == null || !tool.isPrivate())
-            return true;
-
-        String uuid = toolItemStack.getOwner();
-
+        ToolItemStack tis = ToolItemStack.of(itemStack);
+        Tool tool = tis.getTool();
+        if (tool == null || !tool.isPrivate()) return true;
+        String uuid = tis.getOwner();
         return uuid.isEmpty() || player.getUniqueId().toString().equals(uuid);
     }
 
     public static void reload(){
-        WildToolsPlugin.getPlugin().getToolsManager().clearTools();
+        ToolsHandler tm = WildToolsPlugin.getPlugin().getToolsManager();
+        tm.clearTools();
     }
 
-    private <T extends Tool> T getTool(ItemStack itemStack, ToolMode mode, Class<T> clazz){
-        for(Tool tool : tools)
-            if (tool.getToolMode() == mode && tool.isSimilar(itemStack))
-                return clazz.cast(tool);
+    @Override
+    public void registerToolKind(ToolKind kind, ToolKindFactory factory) {
+        kinds.put(kind.id().toUpperCase(), kind);
+        kindFactories.put(kind.id().toUpperCase(), factory);
+    }
 
+    @Override
+    public ToolKind getKind(String id) {
+        return id == null ? null : kinds.get(id.toUpperCase());
+    }
+
+    @Override
+    public Map<String, ToolKind> getRegisteredKinds() {
+        return Collections.unmodifiableMap(kinds);
+    }
+
+    @Override
+    public <T extends Tool> T registerTool(String kindId, Material type, String name, ToolSectionView cfg) {
+        ToolKindFactory factory = kindFactories.get(kindId.toUpperCase());
+        if (factory == null)
+            throw new IllegalArgumentException("Unknown tool kind: " + kindId);
+
+        Tool tool = factory.create(type, name, cfg);
+        if (tool == null)
+            throw new IllegalArgumentException("Tool factory returned null for " + kindId);
+
+        CommonToolLoader.applyCommonProperties(tool, cfg);
+
+        Tool prev = toolsByName.put(tool.getName().toLowerCase(), tool);
+        if (prev != null) tools.remove(prev);
+
+        tools.add(tool);
+        tools.sort(toolComparator);
+        return (T) tool;
+    }
+
+    @Deprecated
+    @Override
+    public <T extends Tool> T registerTool(Material type, String name, Class<T> toolClass, Object arg) {
+        String kindId = LegacyKindMapper.toKindId(toolClass);
+        return registerTool(kindId, type, name, ToolSectionViewAdapters.fromLegacyArg(arg));
+    }
+
+    private <T extends Tool> T getToolByKind(ItemStack stack, ToolMode mode, Class<T> clazz) {
+        return getToolByKind(stack, mode.name(), clazz);
+    }
+
+    private <T extends Tool> T getToolByKind(ItemStack stack, String kindId, Class<T> clazz) {
+        if (stack == null) return null;
+        ToolKind k = getKind(kindId);
+        for (Tool t : tools) {
+            ToolKind tk = t.getKind();
+            if (tk == null || !tk.id().equalsIgnoreCase(kindId)) continue;
+            boolean similar = (k != null && k.isSimilar(stack, t)) || t.isSimilar(stack);
+            if (similar) return clazz.cast(t);
+        }
         return null;
     }
 
+    public void registerBuiltinKindsPublic() {
+        final ToolKind BUILDER = new BuiltinKind(ToolMode.BUILDER, 10);
+        registerToolKind(BUILDER, (type, name, cfg) ->
+                new WBuilderTool(type, name, cfg.getInt("length", 0), BUILDER));
+
+        final ToolKind CANNON = new BuiltinKind(ToolMode.CANNON, 20);
+        registerToolKind(CANNON, (type, name, cfg) ->
+                new WCannonTool(type, name, cfg.getInt("tnt-amount", 0), CANNON));
+
+        final ToolKind CRAFTING = new BuiltinKind(ToolMode.CRAFTING, 30);
+        registerToolKind(CRAFTING, (type, name, cfg) ->
+                new WCraftingTool(type, name, cfg.getStringList("craftings"), CRAFTING));
+
+        final ToolKind CROWBAR = new BuiltinKind(ToolMode.CROWBAR, 40);
+        registerToolKind(CROWBAR, (type, name, cfg) ->
+                new WCrowbarTool(type, name, cfg.getStringList("commands-on-use"), CROWBAR));
+
+        final ToolKind CUBOID = new BuiltinKind(ToolMode.CUBOID, 50);
+        registerToolKind(CUBOID, (type, name, cfg) ->
+                new WCuboidTool(type, name, cfg.getInt("break-level", 1), CUBOID));
+
+        final ToolKind DRAIN = new BuiltinKind(ToolMode.DRAIN, 60);
+        registerToolKind(DRAIN, (type, name, cfg) ->
+                new WDrainTool(type, name, cfg.getInt("radius", 3), DRAIN));
+
+        final ToolKind HARVESTER = new BuiltinKind(ToolMode.HARVESTER, 70);
+        registerToolKind(HARVESTER, (type, name, cfg) -> {
+            WHarvesterTool t = new WHarvesterTool(type, name, cfg.getInt("radius", 3), HARVESTER);
+            t.setActivationAction(cfg.getString("active-action", "RIGHT_CLICK"));
+            t.setFarmlandRadius(cfg.getInt("farmland-radius", 0));
+            t.setOneLayerOnly(cfg.getBoolean("one-layer-only", false));
+            return t;
+        });
+
+        final ToolKind ICE = new BuiltinKind(ToolMode.ICE, 80);
+        registerToolKind(ICE, (type, name, cfg) ->
+                new WIceTool(type, name, cfg.getInt("radius", 3), ICE));
+
+        final ToolKind LIGHTNING = new BuiltinKind(ToolMode.LIGHTNING, 90);
+        registerToolKind(LIGHTNING, (type, name, cfg) ->
+                new WLightningTool(type, name, LIGHTNING));
+
+        final ToolKind MAGNET = new BuiltinKind(ToolMode.MAGNET, 100);
+        registerToolKind(MAGNET, (type, name, cfg) ->
+                new WMagnetTool(type, name, cfg.getInt("radius", 3), MAGNET));
+
+        final ToolKind PILLAR = new BuiltinKind(ToolMode.PILLAR, 110);
+        registerToolKind(PILLAR, (type, name, cfg) ->
+                new WPillarTool(type, name, PILLAR));
+
+        final ToolKind SELL = new BuiltinKind(ToolMode.SELL, 120);
+        registerToolKind(SELL, (type, name, cfg) ->
+                new WSellTool(type, name, SELL));
+
+        final ToolKind SORT = new BuiltinKind(ToolMode.SORT, 130);
+        registerToolKind(SORT, (type, name, cfg) ->
+                new WSortTool(type, name, SORT));
+    }
 }

--- a/src/main/java/com/bgsoftware/wildtools/handlers/config/YamlToolSectionView.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/config/YamlToolSectionView.java
@@ -1,0 +1,52 @@
+package com.bgsoftware.wildtools.handlers.config;
+
+import com.bgsoftware.common.config.CommentedConfiguration;
+import com.bgsoftware.wildtools.api.objects.ToolSectionView;
+
+import java.util.List;
+
+public final class YamlToolSectionView implements ToolSectionView {
+    private final CommentedConfiguration root;
+    private final String base;
+
+    public YamlToolSectionView(CommentedConfiguration root, String basePath) {
+        this.root = root;
+        this.base = basePath.endsWith(".") ? basePath : basePath + ".";
+    }
+
+    @Override
+    public boolean contains(String path) {
+        return root.contains(base + path);
+    }
+
+    @Override
+    public String getString(String path, String def) {
+        String v = root.getString(base + path);
+        return v == null ? def : v;
+    }
+
+    @Override
+    public int getInt(String path, int def) {
+        return root.getInt(base + path, def);
+    }
+
+    @Override
+    public long getLong(String path, long def) {
+        return root.getLong(base + path, def);
+    }
+
+    @Override
+    public double getDouble(String path, double def) {
+        return root.getDouble(base + path, def);
+    }
+
+    @Override
+    public boolean getBoolean(String path, boolean def) {
+        return root.getBoolean(base + path, def);
+    }
+
+    @Override
+    public List<String> getStringList(String path) {
+        return root.getStringList(base + path);
+    }
+}

--- a/src/main/java/com/bgsoftware/wildtools/handlers/kinds/BuiltinKind.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/kinds/BuiltinKind.java
@@ -1,0 +1,31 @@
+package com.bgsoftware.wildtools.handlers.kinds;
+
+import com.bgsoftware.wildtools.api.objects.ToolKind;
+import com.bgsoftware.wildtools.api.objects.ToolMode;
+import com.bgsoftware.wildtools.api.objects.tools.Tool;
+import org.bukkit.inventory.ItemStack;
+
+public final class BuiltinKind implements ToolKind {
+    private final String id;
+    private final int sort;
+
+    public BuiltinKind(ToolMode mode, int sort) {
+        this.id = mode.name();
+        this.sort = sort;
+    }
+
+    @Override
+    public String id() {
+        return id;
+    }
+
+    @Override
+    public int sortOrder() {
+        return sort;
+    }
+
+    @Override
+    public boolean isSimilar(ItemStack stack, Tool tool) {
+        return tool.isSimilar(stack);
+    }
+}

--- a/src/main/java/com/bgsoftware/wildtools/handlers/legacy/LegacyKindMapper.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/legacy/LegacyKindMapper.java
@@ -1,0 +1,25 @@
+package com.bgsoftware.wildtools.handlers.legacy;
+
+import com.bgsoftware.wildtools.api.objects.tools.*;
+
+public final class LegacyKindMapper {
+    private LegacyKindMapper() {
+    }
+
+    public static String toKindId(Class<? extends Tool> toolClass) {
+        if (BuilderTool.class.isAssignableFrom(toolClass)) return "BUILDER";
+        if (CannonTool.class.isAssignableFrom(toolClass)) return "CANNON";
+        if (CraftingTool.class.isAssignableFrom(toolClass)) return "CRAFTING";
+        if (CrowbarTool.class.isAssignableFrom(toolClass)) return "CROWBAR";
+        if (CuboidTool.class.isAssignableFrom(toolClass)) return "CUBOID";
+        if (DrainTool.class.isAssignableFrom(toolClass)) return "DRAIN";
+        if (HarvesterTool.class.isAssignableFrom(toolClass)) return "HARVESTER";
+        if (IceTool.class.isAssignableFrom(toolClass)) return "ICE";
+        if (LightningTool.class.isAssignableFrom(toolClass)) return "LIGHTNING";
+        if (MagnetTool.class.isAssignableFrom(toolClass)) return "MAGNET";
+        if (PillarTool.class.isAssignableFrom(toolClass)) return "PILLAR";
+        if (SellTool.class.isAssignableFrom(toolClass)) return "SELL";
+        if (SortTool.class.isAssignableFrom(toolClass)) return "SORT";
+        throw new IllegalArgumentException("Unknown legacy tool class " + toolClass.getName());
+    }
+}

--- a/src/main/java/com/bgsoftware/wildtools/handlers/legacy/ToolSectionViewAdapters.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/legacy/ToolSectionViewAdapters.java
@@ -1,0 +1,64 @@
+package com.bgsoftware.wildtools.handlers.legacy;
+
+import com.bgsoftware.wildtools.api.objects.ToolSectionView;
+
+import java.util.Collections;
+import java.util.List;
+
+public final class ToolSectionViewAdapters {
+
+    private ToolSectionViewAdapters() {
+    }
+
+    public static ToolSectionView fromLegacyArg(final Object arg) {
+        return new ToolSectionView() {
+
+            @Override
+            public boolean contains(String path) {
+                if (arg == null)
+                    return false;
+                if (path == null)
+                    return false;
+
+                return path.equals("length") || path.equals("tnt-amount") ||
+                        path.equals("break-level") || path.equals("radius") ||
+                        path.equals("craftings") || path.equals("commands-on-use");
+            }
+
+            @Override
+            public String getString(String path, String def) {
+                return def;
+            }
+
+            @Override
+            public int getInt(String path, int def) {
+                if (arg instanceof Number)
+                    return ((Number) arg).intValue();
+                return def;
+            }
+
+            @Override
+            public long getLong(String path, long def) {
+                return def;
+            }
+
+            @Override
+            public double getDouble(String path, double def) {
+                return def;
+            }
+
+            @Override
+            public boolean getBoolean(String path, boolean def) {
+                return def;
+            }
+
+            @Override
+            @SuppressWarnings("unchecked")
+            public List<String> getStringList(String path) {
+                if (arg instanceof List)
+                    return (List<String>) arg;
+                return Collections.emptyList();
+            }
+        };
+    }
+}

--- a/src/main/java/com/bgsoftware/wildtools/handlers/loaders/CommonToolLoader.java
+++ b/src/main/java/com/bgsoftware/wildtools/handlers/loaders/CommonToolLoader.java
@@ -1,0 +1,102 @@
+package com.bgsoftware.wildtools.handlers.loaders;
+
+import com.bgsoftware.wildtools.api.objects.ToolSectionView;
+import com.bgsoftware.wildtools.api.objects.tools.Tool;
+import com.bgsoftware.wildtools.tools.WTool;
+import org.bukkit.enchantments.Enchantment;
+
+import java.util.List;
+
+
+public final class CommonToolLoader {
+
+    private CommonToolLoader() {
+    }
+
+    public static void applyCommonProperties(Tool tool, ToolSectionView cfg) {
+        if (cfg.contains("cooldown"))
+            tool.setCooldown(cfg.getLong("cooldown", 0L));
+        if (cfg.contains("auto-collect"))
+            tool.setAutoCollect(cfg.getBoolean("auto-collect", false));
+        if (cfg.contains("instant-break"))
+            tool.setInstantBreak(cfg.getBoolean("instant-break", false));
+        if (cfg.contains("silk-touch"))
+            tool.setSilkTouch(cfg.getBoolean("silk-touch", false));
+        if (cfg.contains("only-same-type"))
+            tool.setOnlySameType(cfg.getBoolean("only-same-type", false));
+        if (cfg.contains("only-inside-claim"))
+            tool.setOnlyInsideClaim(cfg.getBoolean("only-inside-claim", false));
+        if (cfg.contains("unbreakable"))
+            tool.setUnbreakable(cfg.getBoolean("unbreakable", false));
+        if (cfg.contains("vanilla-damage"))
+            tool.setVanillaDamage(cfg.getBoolean("vanilla-damage", false));
+        if (cfg.contains("uses"))
+            tool.setUsesLeft(cfg.getInt("uses", 0));
+        if (cfg.contains("keep-inventory"))
+            tool.setKeepInventory(cfg.getBoolean("keep-inventory", false));
+        if (cfg.contains("name"))
+            tool.setDisplayName(cfg.getString("name", null));
+        if (cfg.contains("lore"))
+            tool.setLore(cfg.getStringList("lore"));
+        if (cfg.getBoolean("glow", false) && tool instanceof WTool)
+            ((WTool) tool).makeToolGlow();
+        if (cfg.contains("spigot-unbreakable"))
+            tool.setSpigotUnbreakable(cfg.getBoolean("spigot-unbreakable", false));
+        if (cfg.contains("custom-model"))
+            tool.setCustomModel(cfg.getInt("custom-model", 0));
+
+        List<String> enchants = cfg.getStringList("enchants");
+        if (enchants != null) {
+            for (String line : enchants) {
+                try {
+                    String[] s = line.split(":");
+                    Enchantment ench = Enchantment.getByName(s[0]);
+                    int lvl = Integer.parseInt(s[1]);
+                    tool.addEnchantment(ench, lvl);
+                } catch (Exception ignored) {
+                }
+            }
+        }
+
+        List<String> mats = cfg.getStringList("blacklisted-blocks");
+        if (mats != null)
+            for (String m : mats) tool.addBlacklistedMaterial(m);
+
+        mats = cfg.getStringList("whitelisted-blocks");
+        if (mats != null)
+            for (String m : mats) tool.addWhitelistedMaterial(m);
+
+        List<String> drops = cfg.getStringList("blacklisted-drops");
+        if (drops != null)
+            for (String d : drops) tool.addBlacklistedDrop(d);
+
+        drops = cfg.getStringList("whitelisted-drops");
+        if (drops != null)
+            for (String d : drops) tool.addWhitelistedDrop(d);
+
+        if (cfg.contains("multiplier"))
+            tool.setMultiplier(cfg.getDouble("multiplier", 1.0));
+        if (cfg.contains("omni-tool"))
+            tool.setOmni(cfg.getBoolean("omni-tool", false));
+        if (cfg.contains("private"))
+            tool.setPrivate(cfg.getBoolean("private", false));
+        if (cfg.contains("uses-progress"))
+            tool.setUsesProgress(cfg.getBoolean("uses-progress", false));
+        if (cfg.contains("anvil-combine-exp"))
+            tool.setAnvilCombineExp(cfg.getInt("anvil-combine-exp", 0));
+        if (cfg.contains("anvil-combine-limit"))
+            tool.setAnvilCombineLimit(cfg.getInt("anvil-combine-limit", 0));
+
+        List<String> worlds = cfg.getStringList("blacklisted-worlds");
+        if (worlds != null)
+            tool.setBlacklistedWorlds(worlds);
+
+        worlds = cfg.getStringList("whitelisted-worlds");
+        if (worlds != null)
+            tool.setWhitelistedWorlds(worlds);
+
+        List<String> plugins = cfg.getStringList("notified-plugins");
+        if (plugins != null)
+            tool.setNotifiedPlugins(plugins);
+    }
+}

--- a/src/main/java/com/bgsoftware/wildtools/tools/WBuilderTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WBuilderTool.java
@@ -2,6 +2,7 @@ package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.Locale;
 import com.bgsoftware.wildtools.api.events.BuilderWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.BuilderTool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
@@ -22,8 +23,8 @@ public class WBuilderTool extends WTool implements BuilderTool {
 
     private final int length;
 
-    public WBuilderTool(Material type, String name, int length) {
-        super(type, name, ToolMode.BUILDER);
+    public WBuilderTool(Material type, String name, int length, ToolKind kind) {
+        super(type, name, kind);
         this.length = length;
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/tools/WCannonTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WCannonTool.java
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.api.events.CannonWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.utils.WSelection;
 import com.bgsoftware.wildtools.utils.items.ItemUtils;
 import org.bukkit.Bukkit;
@@ -29,8 +30,8 @@ public class WCannonTool extends WTool implements CannonTool {
 
     private final int tntAmount;
 
-    public WCannonTool(Material type, String name, int tntAmount){
-        super(type, name, ToolMode.CANNON);
+    public WCannonTool(Material type, String name, int tntAmount, ToolKind kind){
+        super(type, name, kind);
         this.tntAmount = tntAmount;
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/tools/WCraftingTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WCraftingTool.java
@@ -2,6 +2,7 @@ package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.Locale;
 import com.bgsoftware.wildtools.api.events.CraftingWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.CraftingTool;
 import com.bgsoftware.wildtools.recipes.RecipeChoice;
@@ -31,8 +32,8 @@ public class WCraftingTool extends WTool implements CraftingTool {
 
     private final List<Recipe> craftings;
 
-    public WCraftingTool(Material type, String name, List<String> craftings) {
-        super(type, name, ToolMode.CRAFTING);
+    public WCraftingTool(Material type, String name, List<String> craftings, ToolKind kind) {
+        super(type, name, kind);
         this.craftings = parseCraftings(craftings);
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/tools/WCrowbarTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WCrowbarTool.java
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.api.events.CrowbarWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.CrowbarTool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
@@ -20,8 +21,8 @@ public class WCrowbarTool extends WTool implements CrowbarTool {
 
     private final List<String> commandsOnUse;
 
-    public WCrowbarTool(Material type, String name, List<String> commandsOnUse) {
-        super(type, name, ToolMode.CROWBAR);
+    public WCrowbarTool(Material type, String name, List<String> commandsOnUse, ToolKind kind) {
+        super(type, name, kind);
         this.commandsOnUse = commandsOnUse;
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/tools/WCuboidTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WCuboidTool.java
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.api.events.CuboidWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.CuboidTool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
@@ -17,8 +18,8 @@ public class WCuboidTool extends WTool implements CuboidTool {
 
     private final int breakLevel;
 
-    public WCuboidTool(Material type, String name, int breakLevel) {
-        super(type, name, ToolMode.CUBOID);
+    public WCuboidTool(Material type, String name, int breakLevel, ToolKind kind) {
+        super(type, name, kind);
         this.breakLevel = breakLevel;
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/tools/WDrainTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WDrainTool.java
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.api.events.DrainWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.DrainTool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
@@ -18,8 +19,8 @@ public class WDrainTool extends WTool implements DrainTool {
 
     private final int radius;
 
-    public WDrainTool(Material type, String name, int radius) {
-        super(type, name, ToolMode.DRAIN);
+    public WDrainTool(Material type, String name, int radius, ToolKind kind) {
+        super(type, name, kind);
         this.radius = radius;
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/tools/WHarvesterTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WHarvesterTool.java
@@ -3,6 +3,7 @@ package com.bgsoftware.wildtools.tools;
 import com.bgsoftware.wildtools.Locale;
 import com.bgsoftware.wildtools.api.events.HarvesterHoeSellEvent;
 import com.bgsoftware.wildtools.api.events.HarvesterHoeUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.HarvesterTool;
 import com.bgsoftware.wildtools.scheduler.Scheduler;
@@ -57,8 +58,8 @@ public class WHarvesterTool extends WTool implements HarvesterTool {
     private String activateAction;
     private boolean oneLayerOnly;
 
-    public WHarvesterTool(Material type, String name, int radius) {
-        super(type, name, ToolMode.HARVESTER);
+    public WHarvesterTool(Material type, String name, int radius, ToolKind kind) {
+        super(type, name, kind);
         this.radius = radius;
         this.farmlandRadius = -1;
         this.oneLayerOnly = false;

--- a/src/main/java/com/bgsoftware/wildtools/tools/WIceTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WIceTool.java
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.api.events.IceWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.IceTool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
@@ -18,8 +19,8 @@ public class WIceTool extends WTool implements IceTool {
 
     private final int radius;
 
-    public WIceTool(Material type, String name, int radius) {
-        super(type, name, ToolMode.ICE);
+    public WIceTool(Material type, String name, int radius, ToolKind kind) {
+        super(type, name, kind);
         this.radius = radius;
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/tools/WLightningTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WLightningTool.java
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.api.events.LightningWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.LightningTool;
 import org.bukkit.Bukkit;
@@ -19,8 +20,8 @@ import java.util.List;
 
 public class WLightningTool extends WTool implements LightningTool {
 
-    public WLightningTool(Material type, String name) {
-        super(type, name, ToolMode.LIGHTNING);
+    public WLightningTool(Material type, String name, ToolKind kind) {
+        super(type, name, kind);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/wildtools/tools/WMagnetTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WMagnetTool.java
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.api.events.MagnetWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.MagnetTool;
 import com.bgsoftware.wildtools.events.EventsSimulation;
@@ -21,8 +22,8 @@ public class WMagnetTool extends WTool implements MagnetTool {
 
     private final int radius;
 
-    public WMagnetTool(Material type, String name, int radius) {
-        super(type, name, ToolMode.MAGNET);
+    public WMagnetTool(Material type, String name, int radius, ToolKind kind) {
+        super(type, name, kind);
         this.radius = radius;
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/tools/WPillarTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WPillarTool.java
@@ -1,6 +1,7 @@
 package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.api.events.PillarWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.PillarTool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
@@ -18,8 +19,8 @@ public class WPillarTool extends WTool implements PillarTool {
 
     private static final int MIN_WORLD_HEIGHT = ServerVersion.isAtLeast(ServerVersion.v1_18) ? -64 : 0;
 
-    public WPillarTool(Material type, String name) {
-        super(type, name, ToolMode.PILLAR);
+    public WPillarTool(Material type, String name, ToolKind kind) {
+        super(type, name, kind);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/wildtools/tools/WSellTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WSellTool.java
@@ -5,6 +5,7 @@ import com.bgsoftware.wildtools.SellWandLogger;
 import com.bgsoftware.wildtools.api.events.SellWandUseEvent;
 import com.bgsoftware.wildtools.api.hooks.SellInfo;
 import com.bgsoftware.wildtools.api.hooks.SoldItem;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.SellTool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
@@ -21,8 +22,8 @@ import java.util.Map;
 
 public class WSellTool extends WTool implements SellTool {
 
-    public WSellTool(Material type, String name) {
-        super(type, name, ToolMode.SELL);
+    public WSellTool(Material type, String name, ToolKind kind) {
+        super(type, name, kind);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/wildtools/tools/WSortTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WSortTool.java
@@ -2,6 +2,7 @@ package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.wildtools.Locale;
 import com.bgsoftware.wildtools.api.events.SortWandUseEvent;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
 import com.bgsoftware.wildtools.api.objects.tools.SortTool;
 import com.bgsoftware.wildtools.scheduler.Scheduler;
@@ -25,8 +26,8 @@ import java.util.stream.Collectors;
 
 public class WSortTool extends WTool implements SortTool {
 
-    public WSortTool(Material type, String name) {
-        super(type, name, ToolMode.SORT);
+    public WSortTool(Material type, String name, ToolKind kind) {
+        super(type, name, kind);
     }
 
     @Override

--- a/src/main/java/com/bgsoftware/wildtools/tools/WTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WTool.java
@@ -4,7 +4,6 @@ import com.bgsoftware.common.reflection.ReflectMethod;
 import com.bgsoftware.wildtools.WildToolsPlugin;
 import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
-import com.bgsoftware.wildtools.api.objects.tools.BaseTool;
 import com.bgsoftware.wildtools.api.objects.tools.Tool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
 import com.bgsoftware.wildtools.utils.items.ItemUtils;

--- a/src/main/java/com/bgsoftware/wildtools/tools/WTool.java
+++ b/src/main/java/com/bgsoftware/wildtools/tools/WTool.java
@@ -2,7 +2,9 @@ package com.bgsoftware.wildtools.tools;
 
 import com.bgsoftware.common.reflection.ReflectMethod;
 import com.bgsoftware.wildtools.WildToolsPlugin;
+import com.bgsoftware.wildtools.api.objects.ToolKind;
 import com.bgsoftware.wildtools.api.objects.ToolMode;
+import com.bgsoftware.wildtools.api.objects.tools.BaseTool;
 import com.bgsoftware.wildtools.api.objects.tools.Tool;
 import com.bgsoftware.wildtools.utils.BukkitUtils;
 import com.bgsoftware.wildtools.utils.items.ItemUtils;
@@ -51,7 +53,8 @@ public abstract class WTool implements Tool {
 
     private final ToolItemStack toolItemStack;
     private final String name;
-    private final ToolMode toolMode;
+    private ToolMode toolMode;
+    private ToolKind kind;
 
     private boolean isOnlySameType = false;
     private boolean isOnlyInsideClaim = false;
@@ -71,10 +74,18 @@ public abstract class WTool implements Tool {
     private int anvilCombineExp = -1;
     private int anvilCombineLimit = 0;
 
-    public WTool(Material type, String name, ToolMode toolMode) {
+    public WTool(Material type, String name, ToolKind kind) {
         this.toolItemStack = ToolItemStack.of(type);
-        this.toolMode = toolMode;
         this.name = name;
+        this.kind = kind;
+
+        ToolMode detectedMode = null;
+        try {
+            detectedMode = ToolMode.valueOf(kind.id().toUpperCase());
+        } catch (IllegalArgumentException ignored) {
+        }
+
+        this.toolMode = detectedMode;
     }
 
     @Override
@@ -271,6 +282,11 @@ public abstract class WTool implements Tool {
     @Override
     public ToolMode getToolMode() {
         return this.toolMode;
+    }
+
+    @Override
+    public ToolKind getKind() {
+        return kind;
     }
 
     @Override


### PR DESCRIPTION
Hello,

I implement a way to add new tool mode through the api, it was not a simple thing lol.

I add PluginInitializeEvent event too.

    @EventHandler
    public void onWildToolsInit(PluginInitializeEvent event) {
        ToolsManager tm = event.getPlugin().getToolsManager();

        final ToolKind NORMAL = new ToolKind() {
            @Override public String id() { return "NORMAL"; }
            // Not required
            // @Override public int sortOrder() { return 0; }
            // @Override public boolean isSimilar(ItemStack stack, Tool tool) {
                //return tool.isSimilar(stack);
            //}
        };

        tm.registerToolKind(NORMAL, (type, name, cfg) -> new BaseTool(type, name, NORMAL) {} );

    }
    
    We can use it like that
    
    We can also create class that extends BaseTool to edit existing methods or add new event too
    
    I also fixed one issue i saw on tool DRAIN, that the ToolMode isn't the good one