### PR TITLE
Fixed and improved omni tool

### DIFF
--- a/NMS/src/main/templates/AbstractNMSAdapter.java.template
+++ b/NMS/src/main/templates/AbstractNMSAdapter.java.template
@@ -17,15 +17,12 @@ import net.minecraft.world.entity.LivingEntity;
 import net.minecraft.world.entity.item.ItemEntity;
 import net.minecraft.world.inventory.AnvilMenu;
 import net.minecraft.world.item.ItemStack;
-import net.minecraft.world.item.Items;
 import net.minecraft.world.level.block.Block;
 import net.minecraft.world.level.block.Blocks;
-import net.minecraft.world.level.block.state.BlockState;
 import org.bukkit.Bukkit;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
 import ${CRAFTBUKKIT_PACKAGE}.CraftWorld;
-import ${CRAFTBUKKIT_PACKAGE}.block.data.CraftBlockData;
 import ${CRAFTBUKKIT_PACKAGE}.entity.CraftItem;
 import ${CRAFTBUKKIT_PACKAGE}.entity.CraftLivingEntity;
 import ${CRAFTBUKKIT_PACKAGE}.inventory.CraftInventoryView;
@@ -43,6 +40,7 @@ import org.bukkit.inventory.RecipeChoice;
 import org.bukkit.inventory.ShapedRecipe;
 import org.bukkit.inventory.ShapelessRecipe;
 import org.bukkit.inventory.meta.ItemMeta;
+import org.bukkit.Tag;
 
 import java.util.ArrayList;
 import java.util.Collection;
@@ -55,9 +53,6 @@ public abstract class AbstractNMSAdapter implements NMSAdapter {
             CraftItemStack.class, ItemStack.class, "handle");
 
     private static final EnumMap<Material, DestroySpeedCategory> DESTROY_SPEED_CATEGORIES = new EnumMap<>(Material.class);
-
-    private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
-    private static final ItemStack DIAMOND_SHOVEL_ITEM_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
 
     @Override
     public void loadLegacy() {
@@ -147,13 +142,15 @@ public abstract class AbstractNMSAdapter implements NMSAdapter {
     @Override
     public DestroySpeedCategory getDestroySpeedCategory(Material material) {
         return DESTROY_SPEED_CATEGORIES.computeIfAbsent(material, mat -> {
-            BlockState blockState = ((CraftBlockData) mat.createBlockData()).getState();
-
-            if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, blockState) == 8f) {
+            if (Tag.MINEABLE_AXE.isTagged(mat)) {
                 return DestroySpeedCategory.AXE;
             }
 
-            if (Items.DIAMOND_SHOVEL.getDestroySpeed(DIAMOND_SHOVEL_ITEM_STACK, blockState) == 8f) {
+            if (Tag.MINEABLE_HOE.isTagged(mat)) {
+                return DestroySpeedCategory.HOE;
+            }
+
+            if (Tag.MINEABLE_SHOVEL.isTagged(mat)) {
                 return DestroySpeedCategory.SHOVEL;
             }
 

--- a/NMS/src/main/templates/AbstractNMSAdapter.java.template
+++ b/NMS/src/main/templates/AbstractNMSAdapter.java.template
@@ -46,12 +46,18 @@ import org.bukkit.inventory.meta.ItemMeta;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.List;
 
 public abstract class AbstractNMSAdapter implements NMSAdapter {
 
     private static final ReflectField<ItemStack> ITEM_STACK_HANDLE = new ReflectField<>(
             CraftItemStack.class, ItemStack.class, "handle");
+
+    private static final EnumMap<Material, DestroySpeedCategory> DESTROY_SPEED_CATEGORIES = new EnumMap<>(Material.class);
+
+    private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_SHOVEL_ITEM_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
 
     @Override
     public void loadLegacy() {
@@ -140,15 +146,19 @@ public abstract class AbstractNMSAdapter implements NMSAdapter {
 
     @Override
     public DestroySpeedCategory getDestroySpeedCategory(Material material) {
-        BlockState blockState = ((CraftBlockData) material.createBlockData()).getState();
+        return DESTROY_SPEED_CATEGORIES.computeIfAbsent(material, mat -> {
+            BlockState blockState = ((CraftBlockData) mat.createBlockData()).getState();
 
-        if (Items.DIAMOND_AXE.getDestroySpeed(new ItemStack(Items.DIAMOND_AXE), blockState) == 8f)
-            return DestroySpeedCategory.AXE;
+            if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, blockState) == 8f) {
+                return DestroySpeedCategory.AXE;
+            }
 
-        if (Items.DIAMOND_SHOVEL.getDestroySpeed(new ItemStack(Items.DIAMOND_SHOVEL), blockState) == 8f)
-            return DestroySpeedCategory.SHOVEL;
+            if (Items.DIAMOND_SHOVEL.getDestroySpeed(DIAMOND_SHOVEL_ITEM_STACK, blockState) == 8f) {
+                return DestroySpeedCategory.SHOVEL;
+            }
 
-        return DestroySpeedCategory.PICKAXE;
+            return DestroySpeedCategory.PICKAXE;
+        });
     }
 
     @Override

--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildtools/nms/v1_12_R1/NMSAdapterImpl.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildtools/nms/v1_12_R1/NMSAdapterImpl.java
@@ -40,12 +40,17 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumMap;
 
 public class NMSAdapterImpl implements NMSAdapter {
 
     private static final ReflectField<ItemStack> ITEM_STACK_HANDLE = new ReflectField<>(CraftItemStack.class, ItemStack.class, "handle");
 
+    private static final EnumMap<Material, DestroySpeedCategory> DESTROY_SPEED_CATEGORIES = new EnumMap<>(Material.class);
+
     private static final Enchantment GLOW_ENCHANT = initializeGlowEnchantment();
+    private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_SHOVEL_ITEM_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
 
     @Override
     public ToolItemStack createToolItemStack(org.bukkit.inventory.ItemStack bukkitItem) {
@@ -123,15 +128,19 @@ public class NMSAdapterImpl implements NMSAdapter {
 
     @Override
     public DestroySpeedCategory getDestroySpeedCategory(Material material) {
-        IBlockData blockData = CraftMagicNumbers.getBlock(material).getBlockData();
+        return DESTROY_SPEED_CATEGORIES.computeIfAbsent(material, mat -> {
+            IBlockData blockData = CraftMagicNumbers.getBlock(mat).getBlockData();
 
-        if (Items.DIAMOND_AXE.getDestroySpeed(new ItemStack(Items.DIAMOND_AXE), blockData) == 8f)
-            return DestroySpeedCategory.AXE;
+            if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, blockData) == 8f) {
+                return DestroySpeedCategory.AXE;
+            }
 
-        if (Items.DIAMOND_SHOVEL.getDestroySpeed(new ItemStack(Items.DIAMOND_SHOVEL), blockData) == 8f)
-            return DestroySpeedCategory.SHOVEL;
+            if (Items.DIAMOND_SHOVEL.getDestroySpeed(DIAMOND_SHOVEL_ITEM_STACK, blockData) == 8f) {
+                return DestroySpeedCategory.SHOVEL;
+            }
 
-        return DestroySpeedCategory.PICKAXE;
+            return DestroySpeedCategory.PICKAXE;
+        });
     }
 
     @Override

--- a/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildtools/nms/v1_12_R1/NMSAdapterImpl.java
+++ b/NMS/v1_12_R1/src/main/java/com/bgsoftware/wildtools/nms/v1_12_R1/NMSAdapterImpl.java
@@ -50,6 +50,7 @@ public class NMSAdapterImpl implements NMSAdapter {
 
     private static final Enchantment GLOW_ENCHANT = initializeGlowEnchantment();
     private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_HOE_ITEM_STACK = new ItemStack(Items.DIAMOND_HOE);
     private static final ItemStack DIAMOND_SHOVEL_ITEM_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
 
     @Override
@@ -133,6 +134,10 @@ public class NMSAdapterImpl implements NMSAdapter {
 
             if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, blockData) == 8f) {
                 return DestroySpeedCategory.AXE;
+            }
+
+            if (Items.DIAMOND_HOE.getDestroySpeed(DIAMOND_HOE_ITEM_STACK, blockData) == 8f) {
+                return DestroySpeedCategory.HOE;
             }
 
             if (Items.DIAMOND_SHOVEL.getDestroySpeed(DIAMOND_SHOVEL_ITEM_STACK, blockData) == 8f) {

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildtools/nms/v1_16_R3/NMSAdapterImpl.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildtools/nms/v1_16_R3/NMSAdapterImpl.java
@@ -58,6 +58,7 @@ public class NMSAdapterImpl implements NMSAdapter {
 
     private static final Enchantment GLOW_ENCHANT = initializeGlowEnchantment();
     private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_HOE_ITEM_STACK = new ItemStack(Items.DIAMOND_HOE);
     private static final ItemStack DIAMOND_SHOVEL_ITEM_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
 
     @Override
@@ -141,6 +142,10 @@ public class NMSAdapterImpl implements NMSAdapter {
 
             if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, blockData) == 8f) {
                 return DestroySpeedCategory.AXE;
+            }
+
+            if (Items.DIAMOND_HOE.getDestroySpeed(DIAMOND_HOE_ITEM_STACK, blockData) == 8f) {
+                return DestroySpeedCategory.HOE;
             }
 
             if (Items.DIAMOND_SHOVEL.getDestroySpeed(DIAMOND_SHOVEL_ITEM_STACK, blockData) == 8f) {

--- a/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildtools/nms/v1_16_R3/NMSAdapterImpl.java
+++ b/NMS/v1_16_R3/src/main/java/com/bgsoftware/wildtools/nms/v1_16_R3/NMSAdapterImpl.java
@@ -47,13 +47,18 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumMap;
 import java.util.List;
 
 public class NMSAdapterImpl implements NMSAdapter {
 
     private static final ReflectField<ItemStack> ITEM_STACK_HANDLE = new ReflectField<>(CraftItemStack.class, ItemStack.class, "handle");
 
+    private static final EnumMap<Material, DestroySpeedCategory> DESTROY_SPEED_CATEGORIES = new EnumMap<>(Material.class);
+
     private static final Enchantment GLOW_ENCHANT = initializeGlowEnchantment();
+    private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_SHOVEL_ITEM_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
 
     @Override
     public ToolItemStack createToolItemStack(org.bukkit.inventory.ItemStack bukkitItem) {
@@ -131,15 +136,19 @@ public class NMSAdapterImpl implements NMSAdapter {
 
     @Override
     public DestroySpeedCategory getDestroySpeedCategory(Material material) {
-        IBlockData blockData = CraftMagicNumbers.getBlock(material).getBlockData();
+        return DESTROY_SPEED_CATEGORIES.computeIfAbsent(material, mat -> {
+            IBlockData blockData = CraftMagicNumbers.getBlock(mat).getBlockData();
 
-        if (Items.DIAMOND_AXE.getDestroySpeed(new ItemStack(Items.DIAMOND_AXE), blockData) == 8f)
-            return DestroySpeedCategory.AXE;
+            if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, blockData) == 8f) {
+                return DestroySpeedCategory.AXE;
+            }
 
-        if (Items.DIAMOND_SHOVEL.getDestroySpeed(new ItemStack(Items.DIAMOND_SHOVEL), blockData) == 8f)
-            return DestroySpeedCategory.SHOVEL;
+            if (Items.DIAMOND_SHOVEL.getDestroySpeed(DIAMOND_SHOVEL_ITEM_STACK, blockData) == 8f) {
+                return DestroySpeedCategory.SHOVEL;
+            }
 
-        return DestroySpeedCategory.PICKAXE;
+            return DestroySpeedCategory.PICKAXE;
+        });
     }
 
     @Override

--- a/NMS/v1_7_R4/src/main/java/com/bgsoftware/wildtools/nms/v1_7_R4/NMSAdapterImpl.java
+++ b/NMS/v1_7_R4/src/main/java/com/bgsoftware/wildtools/nms/v1_7_R4/NMSAdapterImpl.java
@@ -46,6 +46,7 @@ public class NMSAdapterImpl implements NMSAdapter {
 
     private static final Enchantment GLOW_ENCHANT = initializeGlowEnchantment();
     private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_HOE_ITEM_STACK = new ItemStack(Items.DIAMOND_HOE);
     private static final ItemStack DIAMOND_SPADE_ITEM_STACK = new ItemStack(Items.DIAMOND_SPADE);
 
     @Override
@@ -128,6 +129,10 @@ public class NMSAdapterImpl implements NMSAdapter {
 
             if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, block) == 8f) {
                 return DestroySpeedCategory.AXE;
+            }
+
+            if (Items.DIAMOND_HOE.getDestroySpeed(DIAMOND_HOE_ITEM_STACK, block) == 8f) {
+                return DestroySpeedCategory.HOE;
             }
 
             if (Items.DIAMOND_SPADE.getDestroySpeed(DIAMOND_SPADE_ITEM_STACK, block) == 8f) {

--- a/NMS/v1_7_R4/src/main/java/com/bgsoftware/wildtools/nms/v1_7_R4/NMSAdapterImpl.java
+++ b/NMS/v1_7_R4/src/main/java/com/bgsoftware/wildtools/nms/v1_7_R4/NMSAdapterImpl.java
@@ -35,13 +35,18 @@ import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumMap;
 import java.util.List;
 
 public class NMSAdapterImpl implements NMSAdapter {
 
     private static final ReflectField<ItemStack> ITEM_STACK_HANDLE = new ReflectField<>(CraftItemStack.class, ItemStack.class, "handle");
 
+    private static final EnumMap<Material, DestroySpeedCategory> DESTROY_SPEED_CATEGORIES = new EnumMap<>(Material.class);
+
     private static final Enchantment GLOW_ENCHANT = initializeGlowEnchantment();
+    private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_SPADE_ITEM_STACK = new ItemStack(Items.DIAMOND_SPADE);
 
     @Override
     public org.bukkit.inventory.ItemStack getItemInHand(Player player) {
@@ -118,15 +123,19 @@ public class NMSAdapterImpl implements NMSAdapter {
 
     @Override
     public DestroySpeedCategory getDestroySpeedCategory(Material material) {
-        Block block = CraftMagicNumbers.getBlock(material);
+        return DESTROY_SPEED_CATEGORIES.computeIfAbsent(material, mat -> {
+            Block block = CraftMagicNumbers.getBlock(mat);
 
-        if (Items.DIAMOND_AXE.getDestroySpeed(new ItemStack(Items.DIAMOND_AXE), block) == 8f)
-            return DestroySpeedCategory.AXE;
+            if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, block) == 8f) {
+                return DestroySpeedCategory.AXE;
+            }
 
-        if (Items.DIAMOND_SPADE.getDestroySpeed(new ItemStack(Items.DIAMOND_SPADE), block) == 8f)
-            return DestroySpeedCategory.SHOVEL;
+            if (Items.DIAMOND_SPADE.getDestroySpeed(DIAMOND_SPADE_ITEM_STACK, block) == 8f) {
+                return DestroySpeedCategory.SHOVEL;
+            }
 
-        return DestroySpeedCategory.PICKAXE;
+            return DestroySpeedCategory.PICKAXE;
+        });
     }
 
     private static Enchantment initializeGlowEnchantment() {

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildtools/nms/v1_8_R3/NMSAdapterImpl.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildtools/nms/v1_8_R3/NMSAdapterImpl.java
@@ -33,12 +33,17 @@ import org.bukkit.inventory.meta.ItemMeta;
 import java.lang.reflect.Field;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.EnumMap;
 
 public class NMSAdapterImpl implements NMSAdapter {
 
     private static final ReflectField<ItemStack> ITEM_STACK_HANDLE = new ReflectField<>(CraftItemStack.class, ItemStack.class, "handle");
 
+    private static final EnumMap<Material, DestroySpeedCategory> DESTROY_SPEED_CATEGORIES = new EnumMap<>(Material.class);
+
     private static final Enchantment GLOW_ENCHANT = initializeGlowEnchantment();
+    private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_SHOVEL_ITEM_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
 
     @Override
     public ToolItemStack createToolItemStack(org.bukkit.inventory.ItemStack bukkitItem) {
@@ -106,15 +111,19 @@ public class NMSAdapterImpl implements NMSAdapter {
 
     @Override
     public DestroySpeedCategory getDestroySpeedCategory(Material material) {
-        Block block = CraftMagicNumbers.getBlock(material);
+        return DESTROY_SPEED_CATEGORIES.computeIfAbsent(material, mat -> {
+            Block block = CraftMagicNumbers.getBlock(mat);
 
-        if (Items.DIAMOND_AXE.getDestroySpeed(new ItemStack(Items.DIAMOND_AXE), block) == 8f)
-            return DestroySpeedCategory.AXE;
+            if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, block) == 8f) {
+                return DestroySpeedCategory.AXE;
+            }
 
-        if (Items.DIAMOND_SHOVEL.getDestroySpeed(new ItemStack(Items.DIAMOND_SHOVEL), block) == 8f)
-            return DestroySpeedCategory.SHOVEL;
+            if (Items.DIAMOND_SHOVEL.getDestroySpeed(DIAMOND_SHOVEL_ITEM_STACK, block) == 8f) {
+                return DestroySpeedCategory.SHOVEL;
+            }
 
-        return DestroySpeedCategory.PICKAXE;
+            return DestroySpeedCategory.PICKAXE;
+        });
     }
 
     private static Enchantment initializeGlowEnchantment() {

--- a/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildtools/nms/v1_8_R3/NMSAdapterImpl.java
+++ b/NMS/v1_8_R3/src/main/java/com/bgsoftware/wildtools/nms/v1_8_R3/NMSAdapterImpl.java
@@ -43,6 +43,7 @@ public class NMSAdapterImpl implements NMSAdapter {
 
     private static final Enchantment GLOW_ENCHANT = initializeGlowEnchantment();
     private static final ItemStack DIAMOND_AXE_ITEM_STACK = new ItemStack(Items.DIAMOND_AXE);
+    private static final ItemStack DIAMOND_HOE_ITEM_STACK = new ItemStack(Items.DIAMOND_HOE);
     private static final ItemStack DIAMOND_SHOVEL_ITEM_STACK = new ItemStack(Items.DIAMOND_SHOVEL);
 
     @Override
@@ -116,6 +117,10 @@ public class NMSAdapterImpl implements NMSAdapter {
 
             if (Items.DIAMOND_AXE.getDestroySpeed(DIAMOND_AXE_ITEM_STACK, block) == 8f) {
                 return DestroySpeedCategory.AXE;
+            }
+
+            if (Items.DIAMOND_HOE.getDestroySpeed(DIAMOND_HOE_ITEM_STACK, block) == 8f) {
+                return DestroySpeedCategory.HOE;
             }
 
             if (Items.DIAMOND_SHOVEL.getDestroySpeed(DIAMOND_SHOVEL_ITEM_STACK, block) == 8f) {

--- a/src/main/java/com/bgsoftware/wildtools/WildToolsPlugin.java
+++ b/src/main/java/com/bgsoftware/wildtools/WildToolsPlugin.java
@@ -22,6 +22,7 @@ import com.bgsoftware.wildtools.listeners.EditorListener;
 import com.bgsoftware.wildtools.listeners.PlayerListener;
 import com.bgsoftware.wildtools.nms.NMSAdapter;
 import com.bgsoftware.wildtools.nms.NMSWorld;
+import com.bgsoftware.wildtools.utils.items.OmniToolHelper;
 import org.bstats.bukkit.Metrics;
 import org.bukkit.entity.Player;
 import org.bukkit.event.inventory.InventoryType;
@@ -69,6 +70,8 @@ public class WildToolsPlugin extends JavaPlugin implements WildTools {
         new Metrics(this, 4107);
 
         log("******** ENABLE START ********");
+
+        OmniToolHelper.init();
 
         try {
             Class.forName("org.bukkit.event.inventory.PrepareAnvilEvent");

--- a/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
+++ b/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
@@ -16,15 +16,11 @@ import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.player.PlayerInteractAtEntityEvent;
 import org.bukkit.event.player.PlayerInteractEvent;
 import org.bukkit.event.player.PlayerItemDamageEvent;
+import org.bukkit.inventory.ItemStack;
 
-import java.util.HashMap;
-import java.util.Map;
-import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 
 public class BlocksListener implements Listener {
-
-    private static final Map<UUID, Material> lastClickedType = new HashMap<>();
 
     private final WildToolsPlugin plugin;
 
@@ -223,31 +219,19 @@ public class BlocksListener implements Listener {
 
     @EventHandler(priority = EventPriority.LOWEST)
     public void onOmniInteract(PlayerInteractEvent e) {
-        if (e.getAction() != Action.LEFT_CLICK_BLOCK)
-            return;
-
-        Material blockType = e.getClickedBlock().getType();
-
-        if (lastClickedType.get(e.getPlayer().getUniqueId()) == blockType)
-            return;
-
-        ToolItemStack toolItemStack = ToolItemStack.of(plugin.getNMSAdapter().getItemInHand(e.getPlayer(), e));
-        Tool tool = toolItemStack.getTool();
-
-        if (tool == null || !tool.isOmni())
-            return;
-
-        String world = e.getClickedBlock().getWorld().getName();
-
-        if (!tool.isWhitelistedWorld(world) || tool.isBlacklistedWorld(world)) {
-            e.setCancelled(true);
+        if (e.getAction() != Action.LEFT_CLICK_BLOCK) {
             return;
         }
 
-        lastClickedType.put(e.getPlayer().getUniqueId(), blockType);
+        ItemStack handItem = plugin.getNMSAdapter().getItemInHand(e.getPlayer(), e);
+
+        if (handItem == null || handItem.getType() == Material.AIR) {
+            return;
+        }
+
+        Material blockType = e.getClickedBlock().getType();
 
         String replaceTypeName;
-
         switch (plugin.getNMSAdapter().getDestroySpeedCategory(blockType)) {
             case AXE:
                 replaceTypeName = "AXE";
@@ -260,10 +244,29 @@ public class BlocksListener implements Listener {
                 break;
         }
 
+        if (handItem.getType().name().endsWith(replaceTypeName)) {
+            return;
+        }
+
+        ToolItemStack toolItemStack = ToolItemStack.of(handItem);
+        Tool tool = toolItemStack.getTool();
+
+        if (tool == null || !tool.isOmni()) {
+            return;
+        }
+
+        String world = e.getClickedBlock().getWorld().getName();
+
+        if (!tool.isWhitelistedWorld(world) || tool.isBlacklistedWorld(world)) {
+            e.setCancelled(true);
+            return;
+        }
+
         Material replaceType = Material.valueOf(toolItemStack.getType().name().split("_")[0] + "_" + replaceTypeName);
 
-        if (toolItemStack.getType() != replaceType)
+        if (toolItemStack.getType() != replaceType) {
             toolItemStack.setType(replaceType);
+        }
     }
 
     private String getTime(long timeLeft) {

--- a/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
+++ b/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
@@ -228,16 +228,12 @@ public class BlocksListener implements Listener {
         ToolItemStack toolItemStack = ToolItemStack.of(handItem);
         Tool tool = toolItemStack.getTool();
 
-        if (tool == null) {
+        if (tool == null || !tool.isOmni()) {
             return;
         }
 
         if (!isWhitelistedWorld(tool, e.getClickedBlock().getWorld())) {
             e.setCancelled(true);
-            return;
-        }
-
-        if (!tool.isOmni()) {
             return;
         }
 

--- a/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
+++ b/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
@@ -4,7 +4,8 @@ import com.bgsoftware.wildtools.Locale;
 import com.bgsoftware.wildtools.WildToolsPlugin;
 import com.bgsoftware.wildtools.api.objects.tools.Tool;
 import com.bgsoftware.wildtools.tools.ToolBreaksTracker;
-import com.bgsoftware.wildtools.utils.ServerVersion;
+import com.bgsoftware.wildtools.utils.items.DestroySpeedCategory;
+import com.bgsoftware.wildtools.utils.items.OmniToolHelper;
 import com.bgsoftware.wildtools.utils.items.ToolItemStack;
 import org.bukkit.Material;
 import org.bukkit.block.BlockFace;
@@ -230,22 +231,8 @@ public class BlocksListener implements Listener {
         }
 
         Material blockType = e.getClickedBlock().getType();
-
-        String replaceTypeName;
-        switch (plugin.getNMSAdapter().getDestroySpeedCategory(blockType)) {
-            case AXE:
-                replaceTypeName = "AXE";
-                break;
-            case HOE:
-                replaceTypeName = "HOE";
-                break;
-            case SHOVEL:
-                replaceTypeName = ServerVersion.isLegacy() ? "SPADE" : "SHOVEL";
-                break;
-            default:
-                replaceTypeName = "PICKAXE";
-                break;
-        }
+        DestroySpeedCategory destroySpeedCategory = plugin.getNMSAdapter().getDestroySpeedCategory(blockType);
+        String replaceTypeName = OmniToolHelper.getToolTypeName(destroySpeedCategory);
 
         if (handItem.getType().name().endsWith(replaceTypeName)) {
             return;

--- a/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
+++ b/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
@@ -236,6 +236,9 @@ public class BlocksListener implements Listener {
             case AXE:
                 replaceTypeName = "AXE";
                 break;
+            case HOE:
+                replaceTypeName = "HOE";
+                break;
             case SHOVEL:
                 replaceTypeName = ServerVersion.isLegacy() ? "SPADE" : "SHOVEL";
                 break;

--- a/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
+++ b/src/main/java/com/bgsoftware/wildtools/listeners/BlocksListener.java
@@ -8,6 +8,7 @@ import com.bgsoftware.wildtools.utils.items.DestroySpeedCategory;
 import com.bgsoftware.wildtools.utils.items.OmniToolHelper;
 import com.bgsoftware.wildtools.utils.items.ToolItemStack;
 import org.bukkit.Material;
+import org.bukkit.World;
 import org.bukkit.block.BlockFace;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -44,9 +45,7 @@ public class BlocksListener implements Listener {
         if (tool == null)
             return;
 
-        String world = e.getBlock().getWorld().getName();
-
-        if (!tool.isWhitelistedWorld(world) || tool.isBlacklistedWorld(world)) {
+        if (!isWhitelistedWorld(tool, e.getBlock().getWorld())) {
             e.setCancelled(true);
             return;
         }
@@ -96,9 +95,7 @@ public class BlocksListener implements Listener {
         if (tool == null)
             return;
 
-        String world = e.getPlayer().getWorld().getName();
-
-        if (!tool.isWhitelistedWorld(world) || tool.isBlacklistedWorld(world)) {
+        if (!isWhitelistedWorld(tool, e.getPlayer().getWorld())) {
             e.setCancelled(true);
             return;
         }
@@ -181,9 +178,7 @@ public class BlocksListener implements Listener {
         if (tool == null)
             return;
 
-        String world = e.getRightClicked().getWorld().getName();
-
-        if (!tool.isWhitelistedWorld(world) || tool.isBlacklistedWorld(world)) {
+        if (!isWhitelistedWorld(tool, e.getRightClicked().getWorld())) {
             e.setCancelled(true);
             return;
         }
@@ -230,33 +225,41 @@ public class BlocksListener implements Listener {
             return;
         }
 
-        Material blockType = e.getClickedBlock().getType();
-        DestroySpeedCategory destroySpeedCategory = plugin.getNMSAdapter().getDestroySpeedCategory(blockType);
-        String replaceTypeName = OmniToolHelper.getToolTypeName(destroySpeedCategory);
-
-        if (handItem.getType().name().endsWith(replaceTypeName)) {
-            return;
-        }
-
         ToolItemStack toolItemStack = ToolItemStack.of(handItem);
         Tool tool = toolItemStack.getTool();
 
-        if (tool == null || !tool.isOmni()) {
+        if (tool == null) {
             return;
         }
 
-        String world = e.getClickedBlock().getWorld().getName();
-
-        if (!tool.isWhitelistedWorld(world) || tool.isBlacklistedWorld(world)) {
+        if (!isWhitelistedWorld(tool, e.getClickedBlock().getWorld())) {
             e.setCancelled(true);
             return;
         }
 
-        Material replaceType = Material.valueOf(toolItemStack.getType().name().split("_")[0] + "_" + replaceTypeName);
-
-        if (toolItemStack.getType() != replaceType) {
-            toolItemStack.setType(replaceType);
+        if (!tool.isOmni()) {
+            return;
         }
+
+        Material toolType = toolItemStack.getType();
+        Material blockType = e.getClickedBlock().getType();
+        DestroySpeedCategory destroySpeedCategory = plugin.getNMSAdapter().getDestroySpeedCategory(blockType);
+
+        if (OmniToolHelper.isAlreadyCorrectToolType(toolType, destroySpeedCategory)) {
+            return;
+        }
+
+        Material newToolType = OmniToolHelper.getNewToolType(toolType, destroySpeedCategory);
+
+        if (toolType != newToolType) {
+            toolItemStack.setType(newToolType);
+        }
+    }
+
+    private boolean isWhitelistedWorld(Tool tool, World world) {
+        String worldName = world.getName();
+
+        return tool.isWhitelistedWorld(worldName) && !tool.isBlacklistedWorld(worldName);
     }
 
     private String getTime(long timeLeft) {

--- a/src/main/java/com/bgsoftware/wildtools/utils/Materials.java
+++ b/src/main/java/com/bgsoftware/wildtools/utils/Materials.java
@@ -29,6 +29,7 @@ public enum Materials {
     LIGHT_BLUE_STAINED_GLASS_PANE("STAINED_GLASS_PANE", 3),
     ENCHANTED_GOLDEN_APPLE("GOLDEN_APPLE", 1);
 
+    private static final EnumSet<Material> TOOLS = EnumSet.noneOf(Material.class);
     private static final Map<Material, EnumSet<Tag>> MATERIAL_TAGS = initializeMaterialTags();
 
     private static int farmlandId = -1;
@@ -105,6 +106,22 @@ public enum Materials {
         return hasMaterialTag(material, Tag.FORCE_UPDATE);
     }
 
+    public static boolean isAxe(Material material) {
+        return hasMaterialTag(material, Tag.AXE);
+    }
+
+    public static boolean isHoe(Material material) {
+        return hasMaterialTag(material, Tag.HOE);
+    }
+
+    public static boolean isPickaxe(Material material) {
+        return hasMaterialTag(material, Tag.PICKAXE);
+    }
+
+    public static boolean isShovel(Material material) {
+        return hasMaterialTag(material, Tag.SHOVEL);
+    }
+
     private static boolean hasMaterialTag(Material material, Tag tag) {
         EnumSet<Tag> tags = MATERIAL_TAGS.get(material);
         return tags != null && tags.contains(tag);
@@ -115,6 +132,10 @@ public enum Materials {
             farmlandId = WildToolsPlugin.getPlugin().getNMSAdapter().getFarmlandId();
 
         return farmlandId;
+    }
+
+    public static EnumSet<Material> getTools() {
+        return TOOLS;
     }
 
     public static Optional<Material> getSafeMaterial(String name) {
@@ -185,6 +206,22 @@ public enum Materials {
             if (materialName.contains("BUCKET")) {
                 tags.add(Tag.BUCKET);
             }
+            if (materialName.endsWith("_AXE")) {
+                tags.add(Tag.AXE);
+                TOOLS.add(material);
+            }
+            if (materialName.endsWith("_HOE")) {
+                tags.add(Tag.HOE);
+                TOOLS.add(material);
+            }
+            if (materialName.endsWith("_PICKAXE")) {
+                tags.add(Tag.PICKAXE);
+                TOOLS.add(material);
+            }
+            if (ServerVersion.isLegacy() ? materialName.endsWith("_SPADE") : materialName.endsWith("_SHOVEL")) {
+                tags.add(Tag.SHOVEL);
+                TOOLS.add(material);
+            }
 
             if (!tags.isEmpty())
                 materialTags.put(material, tags);
@@ -207,7 +244,11 @@ public enum Materials {
         BOTTLE,
         BUCKET,
         BLACKLISTED_BLOCK,
-        FORCE_UPDATE
+        FORCE_UPDATE,
+        AXE,
+        HOE,
+        PICKAXE,
+        SHOVEL,
 
     }
 

--- a/src/main/java/com/bgsoftware/wildtools/utils/items/DestroySpeedCategory.java
+++ b/src/main/java/com/bgsoftware/wildtools/utils/items/DestroySpeedCategory.java
@@ -3,6 +3,7 @@ package com.bgsoftware.wildtools.utils.items;
 public enum DestroySpeedCategory {
 
     AXE,
+    HOE,
     SHOVEL,
     PICKAXE
 

--- a/src/main/java/com/bgsoftware/wildtools/utils/items/OmniToolHelper.java
+++ b/src/main/java/com/bgsoftware/wildtools/utils/items/OmniToolHelper.java
@@ -1,0 +1,29 @@
+package com.bgsoftware.wildtools.utils.items;
+
+import com.bgsoftware.wildtools.utils.ServerVersion;
+
+import java.util.EnumMap;
+
+public class OmniToolHelper {
+
+    private static final EnumMap<DestroySpeedCategory, String> TOOL_TYPE_NAMES = new EnumMap<>(DestroySpeedCategory.class);
+
+    static {
+        TOOL_TYPE_NAMES.put(DestroySpeedCategory.AXE, "AXE");
+        TOOL_TYPE_NAMES.put(DestroySpeedCategory.HOE, "HOE");
+        TOOL_TYPE_NAMES.put(DestroySpeedCategory.PICKAXE, "PICKAXE");
+        TOOL_TYPE_NAMES.put(DestroySpeedCategory.SHOVEL, ServerVersion.isLegacy() ? "SPADE" : "SHOVEL");
+    }
+
+    private OmniToolHelper() {
+    }
+
+    public static void init() {
+        // Do nothing.
+    }
+
+    public static String getToolTypeName(DestroySpeedCategory category) {
+        return TOOL_TYPE_NAMES.get(category);
+    }
+
+}

--- a/src/main/java/com/bgsoftware/wildtools/utils/items/OmniToolHelper.java
+++ b/src/main/java/com/bgsoftware/wildtools/utils/items/OmniToolHelper.java
@@ -1,18 +1,35 @@
 package com.bgsoftware.wildtools.utils.items;
 
+import com.bgsoftware.wildtools.utils.Materials;
 import com.bgsoftware.wildtools.utils.ServerVersion;
+import org.bukkit.Material;
 
 import java.util.EnumMap;
 
 public class OmniToolHelper {
 
-    private static final EnumMap<DestroySpeedCategory, String> TOOL_TYPE_NAMES = new EnumMap<>(DestroySpeedCategory.class);
+    private static final EnumMap<Material, EnumMap<DestroySpeedCategory, Material>> TOOL_TYPE_CACHE = new EnumMap<>(Material.class);
 
     static {
-        TOOL_TYPE_NAMES.put(DestroySpeedCategory.AXE, "AXE");
-        TOOL_TYPE_NAMES.put(DestroySpeedCategory.HOE, "HOE");
-        TOOL_TYPE_NAMES.put(DestroySpeedCategory.PICKAXE, "PICKAXE");
-        TOOL_TYPE_NAMES.put(DestroySpeedCategory.SHOVEL, ServerVersion.isLegacy() ? "SPADE" : "SHOVEL");
+        String shovelSuffix = ServerVersion.isLegacy() ? "SPADE" : "SHOVEL";
+
+        for (Material material : Materials.getTools()) {
+            String toolName = material.name();
+            int lastUnderscoreIndex = toolName.lastIndexOf('_');
+
+            if (lastUnderscoreIndex != -1) {
+                String prefix = toolName.substring(0, lastUnderscoreIndex + 1);
+
+                EnumMap<DestroySpeedCategory, Material> categoryMap = new EnumMap<>(DestroySpeedCategory.class);
+
+                categoryMap.put(DestroySpeedCategory.AXE, getSafeMaterial(prefix + "AXE", material));
+                categoryMap.put(DestroySpeedCategory.HOE, getSafeMaterial(prefix + "HOE", material));
+                categoryMap.put(DestroySpeedCategory.SHOVEL, getSafeMaterial(prefix + shovelSuffix, material));
+                categoryMap.put(DestroySpeedCategory.PICKAXE, getSafeMaterial(prefix + "PICKAXE", material));
+
+                TOOL_TYPE_CACHE.put(material, categoryMap);
+            }
+        }
     }
 
     private OmniToolHelper() {
@@ -22,8 +39,33 @@ public class OmniToolHelper {
         // Do nothing.
     }
 
-    public static String getToolTypeName(DestroySpeedCategory category) {
-        return TOOL_TYPE_NAMES.get(category);
+    public static boolean isAlreadyCorrectToolType(Material toolType, DestroySpeedCategory destroySpeedCategory) {
+        switch (destroySpeedCategory) {
+            case AXE:
+                return Materials.isAxe(toolType);
+            case HOE:
+                return Materials.isHoe(toolType);
+            case SHOVEL:
+                return Materials.isShovel(toolType);
+            case PICKAXE:
+                return Materials.isPickaxe(toolType);
+            default:
+                return false;
+        }
+    }
+
+    public static Material getNewToolType(Material toolType, DestroySpeedCategory category) {
+        EnumMap<DestroySpeedCategory, Material> categoryMap = TOOL_TYPE_CACHE.get(toolType);
+
+        return categoryMap != null ? categoryMap.get(category) : toolType;
+    }
+
+    private static Material getSafeMaterial(String name, Material fallback) {
+        try {
+            return Material.valueOf(name);
+        } catch (IllegalArgumentException e) {
+            return fallback;
+        }
     }
 
 }


### PR DESCRIPTION
Fixes #249 

# Changelog # 
- Optimized the `getDestroySpeedCategory()` method in `NMSAdapter` by creating reference Diamond Axe and Diamond Shovel instances once, rather than upon every method call, and by storing calculated `DestroySpeedCategory` values ​​for materials in an `EnumMap` to avoid creating new block data/state objects when the category has already been determined.
- Additionally, versions 1.17 and higher now use fast `org.bukkit.Tag` lookups instead of simulating block destruction and checking if the speed was 8f.
- Removed the map tracking the last-broken material per player UUID, as it prevented proper tool type switching when a player held multiple omni tools; instead, additional checks were added and the order of some operations was changed to allow the method to return earlier if no tool type change is required.
- Added support for hoes, as many blocks are destroyed fastest with them in newer versions.