### PR TITLE
Removed the ability to use tools in crafting recipes

### DIFF
--- a/src/main/java/com/bgsoftware/wildtools/WildToolsPlugin.java
+++ b/src/main/java/com/bgsoftware/wildtools/WildToolsPlugin.java
@@ -18,6 +18,7 @@ import com.bgsoftware.wildtools.handlers.RecipesHandler;
 import com.bgsoftware.wildtools.handlers.ToolsHandler;
 import com.bgsoftware.wildtools.listeners.AnvilListener;
 import com.bgsoftware.wildtools.listeners.BlocksListener;
+import com.bgsoftware.wildtools.listeners.CraftingListener;
 import com.bgsoftware.wildtools.listeners.EditorListener;
 import com.bgsoftware.wildtools.listeners.PlayerListener;
 import com.bgsoftware.wildtools.nms.NMSAdapter;
@@ -76,6 +77,7 @@ public class WildToolsPlugin extends JavaPlugin implements WildTools {
         } catch (Exception ignored) {
         }
         getServer().getPluginManager().registerEvents(new BlocksListener(this), this);
+        getServer().getPluginManager().registerEvents(new CraftingListener(this), this);
         getServer().getPluginManager().registerEvents(new PlayerListener(this), this);
         getServer().getPluginManager().registerEvents(new EditorListener(this), this);
 

--- a/src/main/java/com/bgsoftware/wildtools/listeners/CraftingListener.java
+++ b/src/main/java/com/bgsoftware/wildtools/listeners/CraftingListener.java
@@ -1,0 +1,40 @@
+package com.bgsoftware.wildtools.listeners;
+
+import com.bgsoftware.wildtools.WildToolsPlugin;
+import com.bgsoftware.wildtools.api.objects.tools.Tool;
+import org.bukkit.Material;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.Listener;
+import org.bukkit.event.inventory.PrepareItemCraftEvent;
+import org.bukkit.inventory.ItemStack;
+
+public class CraftingListener implements Listener {
+
+    private final WildToolsPlugin plugin;
+
+    public CraftingListener(WildToolsPlugin plugin) {
+        this.plugin = plugin;
+    }
+
+    @EventHandler(priority = EventPriority.HIGHEST)
+    public void onPrepareItemCraft(PrepareItemCraftEvent e) {
+        if (e.getInventory().getMatrix() == null) {
+            return;
+        }
+
+        for (ItemStack itemStack : e.getInventory().getMatrix()) {
+            if (itemStack == null || itemStack.getType() == Material.AIR) {
+                continue;
+            }
+
+            Tool tool = plugin.getToolsManager().getTool(itemStack);
+
+            if (tool != null) {
+                e.getInventory().setResult(null);
+                return;
+            }
+        }
+    }
+
+}

--- a/src/main/java/com/bgsoftware/wildtools/listeners/CraftingListener.java
+++ b/src/main/java/com/bgsoftware/wildtools/listeners/CraftingListener.java
@@ -17,9 +17,9 @@ public class CraftingListener implements Listener {
         this.plugin = plugin;
     }
 
-    @EventHandler(priority = EventPriority.HIGHEST)
+    @EventHandler(priority = EventPriority.LOWEST)
     public void onPrepareItemCraft(PrepareItemCraftEvent e) {
-        if (e.getInventory().getMatrix() == null) {
+        if (e.getInventory().getMatrix() == null || e.getInventory().getResult() == null) {
             return;
         }
 


### PR DESCRIPTION
Fixes #148

The recipe book does not allow the use of a tool item at all because it is not a "clean" item (if an item has even just had its name changed in an anvil, it cannot be used in the recipe book either); the reported issue involves someone using Bedrock Edition, so this is a problem specific to that version or Geyser, we cannot influence their interface, as we operate on Java Edition.

However, I added a listener for `PrepareItemCraftEvent` to clear the result item whenever a tool is placed in the crafting matrix.